### PR TITLE
Make basic arithmetic opeations static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0] - 2024-01-19
+
+### Changed
+
+-   Addition, subtraction, multiplication, division, and remainder are now static methods. This is a breaking change.
+
 ## [8.0.0] - 2024-01-19
 
 ### Removed

--- a/tests/add.test.js
+++ b/tests/add.test.js
@@ -11,71 +11,87 @@ const two = new Decimal128("2");
 
 describe("addition", () => {
     test("one plus one equals two", () => {
-        expect(one.add(one).toString()).toStrictEqual("2");
+        expect(Decimal128.add(one, one).toString()).toStrictEqual("2");
     });
     test("one plus minus one equals zero", () => {
-        expect(one.add(minusOne).toString()).toStrictEqual("0");
-        expect(minusOne.add(one).toString()).toStrictEqual("0");
+        expect(Decimal128.add(one, minusOne).toString()).toStrictEqual("0");
+        expect(Decimal128.add(minusOne, one).toString()).toStrictEqual("0");
     });
     test("minus zero plus zero", () => {
-        expect(minusZero.add(zero).toString()).toStrictEqual("0");
+        expect(Decimal128.add(minusZero, zero).toString()).toStrictEqual("0");
     });
     test("minus zero plus minus zero", () => {
-        expect(minusZero.add(minusZero).toString()).toStrictEqual("-0");
+        expect(Decimal128.add(minusZero, minusZero).toString()).toStrictEqual(
+            "-0"
+        );
     });
     test("two negatives", () => {
-        expect(minusOne.add(new Decimal128("-99")).toString()).toStrictEqual(
-            "-100"
-        );
+        expect(
+            Decimal128.add(minusOne, new Decimal128("-99")).toString()
+        ).toStrictEqual("-100");
     });
     test("0.1 + 0.2 = 0.3", () => {
         let a = "0.1";
         let b = "0.2";
         let c = "0.3";
         expect(
-            new Decimal128(a).add(new Decimal128(b)).toString()
+            Decimal128.add(new Decimal128(a), new Decimal128(b)).toString()
         ).toStrictEqual(c);
         expect(
-            new Decimal128(b).add(new Decimal128(a)).toString()
+            Decimal128.add(new Decimal128(b), new Decimal128(a)).toString()
         ).toStrictEqual(c);
     });
     let big = new Decimal128(bigDigits);
     test("big plus zero is OK", () => {
-        expect(big.add(zero).toString()).toStrictEqual(bigDigits);
+        expect(Decimal128.add(big, zero).toString()).toStrictEqual(bigDigits);
     });
     test("zero plus big is OK", () => {
-        expect(zero.add(big).toString()).toStrictEqual(bigDigits);
+        expect(Decimal128.add(zero, big).toString()).toStrictEqual(bigDigits);
     });
     test("big plus one is OK", () => {
-        expect(big.add(one).toString()).toStrictEqual(one.add(big).toString());
+        expect(Decimal128.add(big, one).toString()).toStrictEqual(
+            Decimal128.add(one, big).toString()
+        );
     });
     test("two plus big is not OK (too many significant digits)", () => {
-        expect(() => two.add(big)).toThrow(RangeError);
+        expect(() => Decimal128.add(two, big)).toThrow(RangeError);
     });
     test("big plus two is not OK (too many significant digits)", () => {
-        expect(() => big.add(two)).toThrow(RangeError);
+        expect(() => Decimal128.add(big, two)).toThrow(RangeError);
     });
     describe("non-normalized", () => {
         test("one point zero plus one point zero", () => {
             expect(
-                new Decimal128("1.0").add(new Decimal128("1.0")).toString()
+                Decimal128.add(
+                    new Decimal128("1.0"),
+                    new Decimal128("1.0")
+                ).toString()
             ).toStrictEqual("2.0");
         });
     });
     describe("NaN", () => {
         test("NaN plus NaN is NaN", () => {
             expect(
-                new Decimal128("NaN").add(new Decimal128("NaN")).toString()
+                Decimal128.add(
+                    new Decimal128("NaN"),
+                    new Decimal128("NaN")
+                ).toString()
             ).toStrictEqual("NaN");
         });
         test("NaN plus number", () => {
             expect(
-                new Decimal128("NaN").add(new Decimal128("1")).toString()
+                Decimal128.add(
+                    new Decimal128("NaN"),
+                    new Decimal128("1")
+                ).toString()
             ).toStrictEqual("NaN");
         });
         test("number plus NaN", () => {
             expect(
-                new Decimal128("1").add(new Decimal128("NaN")).toString()
+                Decimal128.add(
+                    new Decimal128("1"),
+                    new Decimal128("NaN")
+                ).toString()
             ).toStrictEqual("NaN");
         });
     });
@@ -83,32 +99,44 @@ describe("addition", () => {
         let posInf = new Decimal128("Infinity");
         let negInf = new Decimal128("-Infinity");
         test("positive infinity plus number", () => {
-            expect(posInf.add(one).toString()).toStrictEqual("Infinity");
+            expect(Decimal128.add(posInf, one).toString()).toStrictEqual(
+                "Infinity"
+            );
         });
         test("negative infinity plus number", () => {
-            expect(negInf.add(one).toString()).toStrictEqual("-Infinity");
+            expect(Decimal128.add(negInf, one).toString()).toStrictEqual(
+                "-Infinity"
+            );
         });
         test("positive infinity plus positive infinity", () => {
-            expect(posInf.add(posInf).toString()).toStrictEqual("Infinity");
+            expect(Decimal128.add(posInf, posInf).toString()).toStrictEqual(
+                "Infinity"
+            );
         });
         test("minus infinity plus minus infinity", () => {
-            expect(negInf.add(negInf).toString()).toStrictEqual("-Infinity");
+            expect(Decimal128.add(negInf, negInf).toString()).toStrictEqual(
+                "-Infinity"
+            );
         });
         test("positive infinity plus negative infinity", () => {
-            expect(posInf.add(negInf).toString()).toStrictEqual("NaN");
+            expect(Decimal128.add(posInf, negInf).toString()).toStrictEqual(
+                "NaN"
+            );
         });
         test("minus infinity plus positive infinity", () => {
-            expect(negInf.add(posInf).toString()).toStrictEqual("NaN");
+            expect(Decimal128.add(negInf, posInf).toString()).toStrictEqual(
+                "NaN"
+            );
         });
         test("add number to positive infinity", () => {
             expect(
-                new Decimal128("123.5").add(posInf).toString()
+                Decimal128.add(new Decimal128("123.5"), posInf).toString()
             ).toStrictEqual("Infinity");
         });
         test("add number to negative infinity", () => {
-            expect(new Decimal128("-2").add(negInf).toString()).toStrictEqual(
-                "-Infinity"
-            );
+            expect(
+                Decimal128.add(new Decimal128("-2"), negInf).toString()
+            ).toStrictEqual("-Infinity");
         });
     });
 });
@@ -116,14 +144,18 @@ describe("addition", () => {
 describe("examples from the General Decimal Arithmetic specification", () => {
     test("example one", () => {
         expect(
-            new Decimal128("12").add(new Decimal128("7.00")).toString()
+            Decimal128.add(
+                new Decimal128("12"),
+                new Decimal128("7.00")
+            ).toString()
         ).toStrictEqual("19.00");
     });
     test("example two", () => {
         expect(
-            new Decimal128("1E2")
-                .add(new Decimal128("1E4"))
-                .toExponentialString()
+            Decimal128.add(
+                new Decimal128("1E2"),
+                new Decimal128("1E4")
+            ).toExponentialString()
         ).toStrictEqual("1.01E+4");
     });
 });

--- a/tests/divide.test.js
+++ b/tests/divide.test.js
@@ -3,60 +3,91 @@ import { Decimal128 } from "../src/decimal128.mjs";
 describe("division", () => {
     test("simple example", () => {
         expect(
-            new Decimal128("4.1").divide(new Decimal128("1.25")).toString()
+            Decimal128.divide(
+                new Decimal128("4.1"),
+                new Decimal128("1.25")
+            ).toString()
         ).toStrictEqual("3.28");
     });
     test("finite decimal representation", () => {
         expect(
-            new Decimal128("0.654").divide(new Decimal128("0.12")).toString()
+            Decimal128.divide(
+                new Decimal128("0.654"),
+                new Decimal128("0.12")
+            ).toString()
         ).toStrictEqual("5.45");
     });
     test("infinite decimal representation", () => {
         expect(
-            new Decimal128("0.11").divide(new Decimal128("0.3")).toString()
+            Decimal128.divide(
+                new Decimal128("0.11"),
+                new Decimal128("0.3")
+            ).toString()
         ).toStrictEqual("0.3666666666666666666666666666666667");
     });
     test("many digits, few significant", () => {
         expect(
-            new Decimal128("0.00000000000000000000000000000000000001")
-                .divide(new Decimal128("2"))
-                .toString()
+            Decimal128.divide(
+                new Decimal128("0.00000000000000000000000000000000000001"),
+                new Decimal128("2")
+            ).toString()
         ).toStrictEqual("0.000000000000000000000000000000000000005");
     });
     test("one third", () => {
         expect(
-            new Decimal128("1").divide(new Decimal128("3")).toString()
+            Decimal128.divide(
+                new Decimal128("1"),
+                new Decimal128("3")
+            ).toString()
         ).toStrictEqual("0.3333333333333333333333333333333333");
     });
     test("one tenth", () => {
         expect(
-            new Decimal128("1").divide(new Decimal128("10")).toString()
+            Decimal128.divide(
+                new Decimal128("1"),
+                new Decimal128("10")
+            ).toString()
         ).toStrictEqual("0.1");
     });
     test("zero divided by zero", () => {
         expect(
-            new Decimal128("0").divide(new Decimal128("0")).toString()
+            Decimal128.divide(
+                new Decimal128("0"),
+                new Decimal128("0")
+            ).toString()
         ).toStrictEqual("NaN");
     });
     describe("NaN", () => {
         test("NaN divided by NaN is NaN", () => {
             expect(
-                new Decimal128("NaN").divide(new Decimal128("NaN")).toString()
+                Decimal128.divide(
+                    new Decimal128("NaN"),
+                    new Decimal128("NaN")
+                ).toString()
             ).toStrictEqual("NaN");
         });
         test("NaN divided by number is NaN", () => {
             expect(
-                new Decimal128("NaN").divide(new Decimal128("1")).toString()
+                Decimal128.divide(
+                    new Decimal128("NaN"),
+                    new Decimal128("1")
+                ).toString()
             ).toStrictEqual("NaN");
         });
         test("number divided by NaN is NaN", () => {
             expect(
-                new Decimal128("1").divide(new Decimal128("NaN")).toString()
+                Decimal128.divide(
+                    new Decimal128("1"),
+                    new Decimal128("NaN")
+                ).toString()
             ).toStrictEqual("NaN");
         });
         test("divide by zero is NaN", () => {
             expect(
-                new Decimal128("42").divide(new Decimal128("0")).toString()
+                Decimal128.divide(
+                    new Decimal128("42"),
+                    new Decimal128("0")
+                ).toString()
             ).toStrictEqual("NaN");
         });
     });
@@ -64,71 +95,88 @@ describe("division", () => {
         let posInf = new Decimal128("Infinity");
         let negInf = new Decimal128("-Infinity");
         test("infinity divided by infinity is NaN", () => {
-            expect(posInf.divide(posInf).toString()).toStrictEqual("NaN");
+            expect(Decimal128.divide(posInf, posInf).toString()).toStrictEqual(
+                "NaN"
+            );
         });
         test("infinity divided by negative infinity is NaN", () => {
-            expect(posInf.divide(negInf).toString()).toStrictEqual("NaN");
+            expect(Decimal128.divide(posInf, negInf).toString()).toStrictEqual(
+                "NaN"
+            );
         });
         test("negative infinity divided by infinity is NaN", () => {
-            expect(negInf.divide(posInf).toString()).toStrictEqual("NaN");
+            expect(Decimal128.divide(negInf, posInf).toString()).toStrictEqual(
+                "NaN"
+            );
         });
         test("negative infinity divided by positive infinity is NaN", () => {
-            expect(negInf.divide(posInf).toString()).toStrictEqual("NaN");
+            expect(Decimal128.divide(negInf, posInf).toString()).toStrictEqual(
+                "NaN"
+            );
         });
         test("positive infinity divided by positive number", () => {
             expect(
-                posInf.divide(new Decimal128("123.5")).toString()
+                Decimal128.divide(posInf, new Decimal128("123.5")).toString()
             ).toStrictEqual("Infinity");
         });
         test("positive infinity divided by negative number", () => {
             expect(
-                posInf.divide(new Decimal128("-2")).toString()
+                Decimal128.divide(posInf, new Decimal128("-2")).toString()
             ).toStrictEqual("-Infinity");
         });
         test("minus infinity divided by positive number", () => {
             expect(
-                negInf.divide(new Decimal128("17")).toString()
+                Decimal128.divide(negInf, new Decimal128("17")).toString()
             ).toStrictEqual("-Infinity");
         });
         test("minus infinity divided by negative number", () => {
             expect(
-                negInf.divide(new Decimal128("-99.3")).toString()
+                Decimal128.divide(negInf, new Decimal128("-99.3")).toString()
             ).toStrictEqual("Infinity");
         });
         test("positive number divided bv positive infinity", () => {
             expect(
-                new Decimal128("123.5").divide(posInf).toString()
+                Decimal128.divide(new Decimal128("123.5"), posInf).toString()
             ).toStrictEqual("0");
         });
         test("positive number divided bv negative infinity", () => {
             expect(
-                new Decimal128("123.5").divide(negInf).toString()
+                Decimal128.divide(new Decimal128("123.5"), negInf).toString()
             ).toStrictEqual("-0");
         });
         test("negative number divided by positive infinity", () => {
             expect(
-                new Decimal128("-2").divide(posInf).toString()
+                Decimal128.divide(new Decimal128("-2"), posInf).toString()
             ).toStrictEqual("-0");
         });
         test("negative number divided by negative infinity", () => {
             expect(
-                new Decimal128("-2").divide(negInf).toString()
+                Decimal128.divide(new Decimal128("-2"), negInf).toString()
             ).toStrictEqual("0");
         });
     });
     test("negative zero", () => {
         expect(
-            new Decimal128("-0").divide(new Decimal128("1")).toString()
+            Decimal128.divide(
+                new Decimal128("-0"),
+                new Decimal128("1")
+            ).toString()
         ).toStrictEqual("-0");
     });
     test("negative argument", () => {
         expect(
-            new Decimal128("42.6").divide(new Decimal128("-2.0")).toString()
+            Decimal128.divide(
+                new Decimal128("42.6"),
+                new Decimal128("-2.0")
+            ).toString()
         ).toStrictEqual("-21.3");
     });
     test("dividend and divisor are both negative", () => {
         expect(
-            new Decimal128("-42.6").divide(new Decimal128("-2.0")).toString()
+            Decimal128.divide(
+                new Decimal128("-42.6"),
+                new Decimal128("-2.0")
+            ).toString()
         ).toStrictEqual("21.3");
     });
 });
@@ -137,54 +185,82 @@ describe("examples from the General Decimal Arithmetic Specification", () => {
     // some examples have been tweaked because we are working with more precision in Decimal128
     test("example one", () => {
         expect(
-            new Decimal128("1").divide(new Decimal128("3")).toString()
+            Decimal128.divide(
+                new Decimal128("1"),
+                new Decimal128("3")
+            ).toString()
         ).toStrictEqual("0.3333333333333333333333333333333333");
     });
     test("example two", () => {
         expect(
-            new Decimal128("2").divide(new Decimal128("3")).toString()
+            Decimal128.divide(
+                new Decimal128("2"),
+                new Decimal128("3")
+            ).toString()
         ).toStrictEqual("0.6666666666666666666666666666666667");
     });
     test("example three", () => {
         expect(
-            new Decimal128("5").divide(new Decimal128("2")).toString()
+            Decimal128.divide(
+                new Decimal128("5"),
+                new Decimal128("2")
+            ).toString()
         ).toStrictEqual("2.5");
     });
     test("example four", () => {
         expect(
-            new Decimal128("1").divide(new Decimal128("10")).toString()
+            Decimal128.divide(
+                new Decimal128("1"),
+                new Decimal128("10")
+            ).toString()
         ).toStrictEqual("0.1");
     });
     test("example five", () => {
         expect(
-            new Decimal128("12").divide(new Decimal128("12")).toString()
+            Decimal128.divide(
+                new Decimal128("12"),
+                new Decimal128("12")
+            ).toString()
         ).toStrictEqual("1");
     });
     test("example six", () => {
         expect(
-            new Decimal128("8.00").divide(new Decimal128("2")).toString()
+            Decimal128.divide(
+                new Decimal128("8.00"),
+                new Decimal128("2")
+            ).toString()
         ).toStrictEqual("4.00");
     });
     test("example seven", () => {
         expect(
-            new Decimal128("2.400").divide(new Decimal128("2.0")).toString()
+            Decimal128.divide(
+                new Decimal128("2.400"),
+                new Decimal128("2.0")
+            ).toString()
         ).toStrictEqual("1.20");
     });
     test("example eight", () => {
         expect(
-            new Decimal128("1000").divide(new Decimal128("100")).toString()
+            Decimal128.divide(
+                new Decimal128("1000"),
+                new Decimal128("100")
+            ).toString()
         ).toStrictEqual("10");
     });
     test("example nine", () => {
         expect(
-            new Decimal128("1000").divide(new Decimal128("1")).toString()
+            Decimal128.divide(
+                new Decimal128("1000"),
+                new Decimal128("1")
+            ).toString()
         ).toStrictEqual("1000");
     });
     test("example ten", () => {
         expect(
-            new Decimal128("2.40E+6")
-                .divide(new Decimal128("2"))
-                .toExponentialString()
+            Decimal128.divide(
+                new Decimal128("2.40E+6"),
+                new Decimal128("2")
+            ).toExponentialString()
         ).toStrictEqual("1.20E+6");
     });
 });

--- a/tests/multiply.test.js
+++ b/tests/multiply.test.js
@@ -22,7 +22,7 @@ const examples = [
 
 function checkProduct(a, b, c) {
     expect(
-        new Decimal128(a).multiply(new Decimal128(b)).toString()
+        Decimal128.multiply(new Decimal128(a), new Decimal128(b)).toString()
     ).toStrictEqual(c);
 }
 
@@ -44,14 +44,16 @@ describe("multiplication", () => {
     });
     test("integer overflow", () => {
         expect(() =>
-            new Decimal128("123456789123456789").multiply(
+            Decimal128.multiply(
+                new Decimal128("123456789123456789"),
                 new Decimal128("987654321987654321")
             )
         ).toThrow(RangeError);
     });
     test("decimal overflow", () => {
         expect(() =>
-            new Decimal128("123456789123456789.987654321").multiply(
+            Decimal128.multiply(
+                new Decimal128("123456789123456789.987654321"),
                 new Decimal128("987654321123456789.123456789")
             )
         ).toThrow(RangeError);
@@ -59,17 +61,26 @@ describe("multiplication", () => {
     describe("NaN", () => {
         test("NaN times NaN is NaN", () => {
             expect(
-                new Decimal128("NaN").multiply(new Decimal128("NaN")).toString()
+                Decimal128.multiply(
+                    new Decimal128("NaN"),
+                    new Decimal128("NaN")
+                ).toString()
             ).toStrictEqual("NaN");
         });
         test("number times NaN is NaN", () => {
             expect(
-                new Decimal128("1").multiply(new Decimal128("NaN")).toString()
+                Decimal128.multiply(
+                    new Decimal128("1"),
+                    new Decimal128("NaN")
+                ).toString()
             ).toStrictEqual("NaN");
         });
         test("NaN times number is NaN", () => {
             expect(
-                new Decimal128("NaN").multiply(new Decimal128("1")).toString()
+                Decimal128.multiply(
+                    new Decimal128("NaN"),
+                    new Decimal128("1")
+                ).toString()
             ).toStrictEqual("NaN");
         });
     });
@@ -77,83 +88,95 @@ describe("multiplication", () => {
         describe("invalid operation", () => {
             test("zero times positive infinity is NaN", () => {
                 expect(
-                    new Decimal128("0")
-                        .multiply(new Decimal128("Infinity"))
-                        .toString()
+                    Decimal128.multiply(
+                        new Decimal128("0"),
+                        new Decimal128("Infinity")
+                    ).toString()
                 ).toStrictEqual("NaN");
                 expect(
-                    new Decimal128("Infinity")
-                        .multiply(new Decimal128("0"))
-                        .toString()
+                    Decimal128.multiply(
+                        new Decimal128("Infinity"),
+                        new Decimal128("0")
+                    ).toString()
                 ).toStrictEqual("NaN");
             });
             test("zero times negative infinity is NaN", () => {
                 expect(
-                    new Decimal128("0")
-                        .multiply(new Decimal128("-Infinity"))
-                        .toString()
+                    Decimal128.multiply(
+                        new Decimal128("0"),
+                        new Decimal128("-Infinity")
+                    ).toString()
                 ).toStrictEqual("NaN");
                 expect(
-                    new Decimal128("-Infinity")
-                        .multiply(new Decimal128("0"))
-                        .toString()
+                    Decimal128.multiply(
+                        new Decimal128("-Infinity"),
+                        new Decimal128("0")
+                    ).toString()
                 ).toStrictEqual("NaN");
             });
         });
         test("positive infinity times positive number is positive infinity", () => {
             expect(
-                new Decimal128("Infinity")
-                    .multiply(new Decimal128("42"))
-                    .toString()
+                Decimal128.multiply(
+                    new Decimal128("Infinity"),
+                    new Decimal128("42")
+                ).toString()
             ).toStrictEqual("Infinity");
         });
         test("positive number times positive infinity is positive infinity", () => {
             expect(
-                new Decimal128("42")
-                    .multiply(new Decimal128("Infinity"))
-                    .toString()
+                Decimal128.multiply(
+                    new Decimal128("42"),
+                    new Decimal128("Infinity")
+                ).toString()
             ).toStrictEqual("Infinity");
         });
         test("positive infinity times negative number is negative infinity", () => {
             expect(
-                new Decimal128("Infinity")
-                    .multiply(new Decimal128("-42"))
-                    .toString()
+                Decimal128.multiply(
+                    new Decimal128("Infinity"),
+                    new Decimal128("-42")
+                ).toString()
             ).toStrictEqual("-Infinity");
         });
         test("negative number times positive infinity is negative infinity", () => {
             expect(
-                new Decimal128("-42")
-                    .multiply(new Decimal128("Infinity"))
-                    .toString()
+                Decimal128.multiply(
+                    new Decimal128("-42"),
+                    new Decimal128("Infinity")
+                ).toString()
             ).toStrictEqual("-Infinity");
         });
         test("positive infinity times negative infinity is negative infinity", () => {
             expect(
-                new Decimal128("Infinity")
-                    .multiply(new Decimal128("-Infinity"))
-                    .toString()
+                Decimal128.multiply(
+                    new Decimal128("Infinity"),
+                    new Decimal128("-Infinity")
+                ).toString()
             ).toStrictEqual("-Infinity");
         });
         test("positive infinity times positive infinity is positive infinity", () => {
             expect(
-                new Decimal128("Infinity")
-                    .multiply(new Decimal128("Infinity"))
-                    .toString()
+                Decimal128.multiply(
+                    new Decimal128("Infinity"),
+                    new Decimal128("Infinity")
+                ).toString()
             ).toStrictEqual("Infinity");
         });
         test("negative infinity times negative infinity is positive infinity", () => {
             expect(
-                new Decimal128("-Infinity")
-                    .multiply(new Decimal128("-Infinity"))
-                    .toString()
+                Decimal128.multiply(
+                    new Decimal128("-Infinity"),
+                    new Decimal128("-Infinity")
+                ).toString()
             ).toStrictEqual("Infinity");
         });
         test("negative infinity times positive infinity is negative infinity", () => {
             expect(
-                new Decimal128("-Infinity")
-                    .multiply(new Decimal128("Infinity"))
-                    .toString()
+                Decimal128.multiply(
+                    new Decimal128("-Infinity"),
+                    new Decimal128("Infinity")
+                ).toString()
             ).toStrictEqual("-Infinity");
         });
     });
@@ -162,30 +185,43 @@ describe("multiplication", () => {
 describe("examples from the General Decimal Arithmetic specification", () => {
     test("example one", () => {
         expect(
-            new Decimal128("1.20").multiply(new Decimal128("3")).toString()
+            Decimal128.multiply(
+                new Decimal128("1.20"),
+                new Decimal128("3")
+            ).toString()
         ).toStrictEqual("3.60");
     });
     test("example two", () => {
         expect(
-            new Decimal128("7").multiply(new Decimal128("3")).toString()
+            Decimal128.multiply(
+                new Decimal128("7"),
+                new Decimal128("3")
+            ).toString()
         ).toStrictEqual("21");
     });
     test("example three", () => {
         expect(
-            new Decimal128("0.9").multiply(new Decimal128("0.8")).toString()
+            Decimal128.multiply(
+                new Decimal128("0.9"),
+                new Decimal128("0.8")
+            ).toString()
         ).toStrictEqual("0.72");
     });
     test("example four", () => {
         expect(
-            new Decimal128("0.9").multiply(new Decimal128("-0")).toString()
+            Decimal128.multiply(
+                new Decimal128("0.9"),
+                new Decimal128("-0")
+            ).toString()
         ).toStrictEqual("-0.0");
     });
     test("example five", () => {
         // slightly modified because we have more precision
         expect(
-            new Decimal128("654321")
-                .multiply(new Decimal128("654321"))
-                .toExponentialString()
+            Decimal128.multiply(
+                new Decimal128("654321"),
+                new Decimal128("654321")
+            ).toExponentialString()
         ).toStrictEqual("4.28135971041E+11");
     });
 });

--- a/tests/remainder.test.js
+++ b/tests/remainder.test.js
@@ -6,55 +6,83 @@ const b = "1.25";
 describe("remainder", () => {
     test("simple example", () => {
         expect(
-            new Decimal128(a).remainder(new Decimal128(b)).toString()
+            Decimal128.remainder(
+                new Decimal128(a),
+                new Decimal128(b)
+            ).toString()
         ).toStrictEqual("0.35");
     });
     test("negative, with positive argument", () => {
         expect(
-            new Decimal128("-4.1").remainder(new Decimal128(b)).toString()
+            Decimal128.remainder(
+                new Decimal128("-4.1"),
+                new Decimal128(b)
+            ).toString()
         ).toStrictEqual("-0.35");
     });
     test("negative argument", () => {
         expect(
-            new Decimal128(a).remainder(new Decimal128("-1.25")).toString()
+            Decimal128.remainder(
+                new Decimal128(a),
+                new Decimal128("-1.25")
+            ).toString()
         ).toStrictEqual("0.35");
     });
     test("negative, with negative argument", () => {
         expect(
-            new Decimal128("-4.1").remainder(new Decimal128("-1.25")).toString()
+            Decimal128.remainder(
+                new Decimal128("-4.1"),
+                new Decimal128("-1.25")
+            ).toString()
         ).toStrictEqual("-0.35");
     });
     test("divide by zero", () => {
         expect(
-            new Decimal128("42").remainder(new Decimal128("0")).toString()
+            Decimal128.remainder(
+                new Decimal128("42"),
+                new Decimal128("0")
+            ).toString()
         ).toStrictEqual("NaN");
     });
     test("divide by minus zero", () => {
         expect(
-            new Decimal128("42").remainder(new Decimal128("-0")).toString()
+            Decimal128.remainder(
+                new Decimal128("42"),
+                new Decimal128("-0")
+            ).toString()
         ).toStrictEqual("NaN");
     });
     test("cleanly divides", () => {
         expect(
-            new Decimal128("10").remainder(new Decimal128("5")).toString()
+            Decimal128.remainder(
+                new Decimal128("10"),
+                new Decimal128("5")
+            ).toString()
         ).toStrictEqual("0");
     });
     describe("NaN", () => {
         test("NaN remainder NaN is NaN", () => {
             expect(
-                new Decimal128("NaN")
-                    .remainder(new Decimal128("NaN"))
-                    .toString()
+                Decimal128.remainder(
+                    new Decimal128("NaN"),
+                    new Decimal128("NaN")
+                ).toString()
             ).toStrictEqual("NaN");
         });
         test("number remainder NaN is NaN", () => {
             expect(
-                new Decimal128("1").remainder(new Decimal128("NaN")).toString()
+                Decimal128.remainder(
+                    new Decimal128("1"),
+                    new Decimal128("NaN")
+                ).toString()
             ).toStrictEqual("NaN");
         });
         test("NaN remainder number is NaN", () => {
             expect(
-                new Decimal128("NaN").remainder(new Decimal128("1")).toString()
+                Decimal128.remainder(
+                    new Decimal128("NaN"),
+                    new Decimal128("1")
+                ).toString()
             ).toStrictEqual("NaN");
         });
     });
@@ -62,32 +90,38 @@ describe("remainder", () => {
         let posInf = new Decimal128("Infinity");
         let negInf = new Decimal128("-Infinity");
         test("positive infinity remainder positive infinity is NaN", () => {
-            expect(posInf.remainder(posInf).toString()).toStrictEqual("NaN");
+            expect(
+                Decimal128.remainder(posInf, posInf).toString()
+            ).toStrictEqual("NaN");
         });
         test("positive infinity remainder negative infinity is NaN", () => {
-            expect(posInf.remainder(negInf).toString()).toStrictEqual("NaN");
+            expect(
+                Decimal128.remainder(posInf, negInf).toString()
+            ).toStrictEqual("NaN");
         });
         test("negative infinity remainder positive infinity is NaN", () => {
-            expect(negInf.remainder(posInf).toString()).toStrictEqual("NaN");
+            expect(
+                Decimal128.remainder(negInf, posInf).toString()
+            ).toStrictEqual("NaN");
         });
         test("remainder with positive infinity", () => {
             expect(
-                new Decimal128("42").remainder(posInf).toString()
+                Decimal128.remainder(new Decimal128("42"), posInf).toString()
             ).toStrictEqual("42");
         });
         test("remainder with negative infinity", () => {
             expect(
-                new Decimal128("42").remainder(negInf).toString()
+                Decimal128.remainder(new Decimal128("42"), negInf).toString()
             ).toStrictEqual("42");
         });
         test("positive infinity remainder number is NaN", () => {
             expect(
-                posInf.remainder(new Decimal128("42")).toString()
+                Decimal128.remainder(posInf, new Decimal128("42")).toString()
             ).toStrictEqual("NaN");
         });
         test("negative infinity remainder number is NaN", () => {
             expect(
-                negInf.remainder(new Decimal128("42")).toString()
+                Decimal128.remainder(negInf, new Decimal128("42")).toString()
             ).toStrictEqual("NaN");
         });
     });
@@ -96,32 +130,50 @@ describe("remainder", () => {
 describe("examples from the General Decimal Arithmetic Specification", () => {
     test("example one", () => {
         expect(
-            new Decimal128("2.1").remainder(new Decimal128("3")).toString()
+            Decimal128.remainder(
+                new Decimal128("2.1"),
+                new Decimal128("3")
+            ).toString()
         ).toStrictEqual("2.1");
     });
     test("example two", () => {
         expect(
-            new Decimal128("10").remainder(new Decimal128("3")).toString()
+            Decimal128.remainder(
+                new Decimal128("10"),
+                new Decimal128("3")
+            ).toString()
         ).toStrictEqual("1");
     });
     test("example three", () => {
         expect(
-            new Decimal128("-10").remainder(new Decimal128("3")).toString()
+            Decimal128.remainder(
+                new Decimal128("-10"),
+                new Decimal128("3")
+            ).toString()
         ).toStrictEqual("-1");
     });
     test("example four", () => {
         expect(
-            new Decimal128("10.2").remainder(new Decimal128("1")).toString()
+            Decimal128.remainder(
+                new Decimal128("10.2"),
+                new Decimal128("1")
+            ).toString()
         ).toStrictEqual("0.2");
     });
     test("example five", () => {
         expect(
-            new Decimal128("10").remainder(new Decimal128("0.3")).toString()
+            Decimal128.remainder(
+                new Decimal128("10"),
+                new Decimal128("0.3")
+            ).toString()
         ).toStrictEqual("0.1");
     });
     test("example six", () => {
         expect(
-            new Decimal128("3.6").remainder(new Decimal128("1.3")).toString()
+            Decimal128.remainder(
+                new Decimal128("3.6"),
+                new Decimal128("1.3")
+            ).toString()
         ).toStrictEqual("1.0");
     });
 });

--- a/tests/subtract.test.js
+++ b/tests/subtract.test.js
@@ -7,48 +7,63 @@ let bigDigits = "9".repeat(MAX_SIGNIFICANT_DIGITS);
 describe("subtraction", () => {
     test("subtract decimal part", () => {
         expectDecimal128(
-            new Decimal128("123.456").subtract(new Decimal128("0.456")),
+            Decimal128.subtract(
+                new Decimal128("123.456"),
+                new Decimal128("0.456")
+            ),
             "123.000"
         );
     });
     test("minus negative number", () => {
         expectDecimal128(
-            new Decimal128("0.1").subtract(new Decimal128("-0.2")),
+            Decimal128.subtract(new Decimal128("0.1"), new Decimal128("-0.2")),
             "0.3"
         );
     });
     test("subtract two negatives", () => {
         expectDecimal128(
-            new Decimal128("-1.9").subtract(new Decimal128("-2.7")),
+            Decimal128.subtract(new Decimal128("-1.9"), new Decimal128("-2.7")),
             "0.8"
         );
     });
     const big = new Decimal128(bigDigits);
     test("close to range limit", () => {
         expectDecimal128(
-            big.subtract(new Decimal128("9")),
+            Decimal128.subtract(big, new Decimal128("9")),
             "9".repeat(MAX_SIGNIFICANT_DIGITS - 1) + "0"
         );
     });
     test("integer overflow", () => {
         expect(() =>
-            new Decimal128("-" + bigDigits).subtract(new Decimal128("9"))
+            Decimal128.subtract(
+                new Decimal128("-" + bigDigits),
+                new Decimal128("9")
+            )
         ).toThrow(RangeError);
     });
     describe("NaN", () => {
         test("NaN minus NaN is NaN", () => {
             expect(
-                new Decimal128("NaN").subtract(new Decimal128("NaN")).toString()
+                Decimal128.subtract(
+                    new Decimal128("NaN"),
+                    new Decimal128("NaN")
+                ).toString()
             ).toStrictEqual("NaN");
         });
         test("NaN minus number", () => {
             expect(
-                new Decimal128("NaN").subtract(new Decimal128("1")).toString()
+                Decimal128.subtract(
+                    new Decimal128("NaN"),
+                    new Decimal128("1")
+                ).toString()
             ).toStrictEqual("NaN");
         });
         test("number minus NaN", () => {
             expect(
-                new Decimal128("1").subtract(new Decimal128("NaN")).toString()
+                Decimal128.subtract(
+                    new Decimal128("1"),
+                    new Decimal128("NaN")
+                ).toString()
             ).toStrictEqual("NaN");
         });
     });
@@ -61,41 +76,45 @@ describe("infinity", () => {
         describe("positive infinity", () => {
             test("positive number", () => {
                 expect(
-                    posInf.subtract(new Decimal128("1")).toString()
+                    Decimal128.subtract(posInf, new Decimal128("1")).toString()
                 ).toStrictEqual("Infinity");
             });
             test("negative number", () => {
                 expect(
-                    posInf.subtract(new Decimal128("-1")).toString()
+                    Decimal128.subtract(posInf, new Decimal128("-1")).toString()
                 ).toStrictEqual("Infinity");
             });
             test("positive infinity", () => {
-                expect(posInf.subtract(posInf).toString()).toStrictEqual("NaN");
+                expect(
+                    Decimal128.subtract(posInf, posInf).toString()
+                ).toStrictEqual("NaN");
             });
             test("negative infinity", () => {
-                expect(posInf.subtract(negInf).toString()).toStrictEqual(
-                    "Infinity"
-                );
+                expect(
+                    Decimal128.subtract(posInf, negInf).toString()
+                ).toStrictEqual("Infinity");
             });
         });
         describe("negative infinity", () => {
             test("positive number", () => {
                 expect(
-                    negInf.subtract(new Decimal128("1")).toString()
+                    Decimal128.subtract(negInf, new Decimal128("1")).toString()
                 ).toStrictEqual("-Infinity");
             });
             test("negative number", () => {
                 expect(
-                    negInf.subtract(new Decimal128("-1")).toString()
+                    Decimal128.subtract(negInf, new Decimal128("-1")).toString()
                 ).toStrictEqual("-Infinity");
             });
             test("positive infinity", () => {
-                expect(negInf.subtract(posInf).toString()).toStrictEqual(
-                    "-Infinity"
-                );
+                expect(
+                    Decimal128.subtract(negInf, posInf).toString()
+                ).toStrictEqual("-Infinity");
             });
             test("negative infinity", () => {
-                expect(negInf.subtract(negInf).toString()).toStrictEqual("NaN");
+                expect(
+                    Decimal128.subtract(negInf, negInf).toString()
+                ).toStrictEqual("NaN");
             });
         });
     });
@@ -103,31 +122,35 @@ describe("infinity", () => {
         describe("positive infinity", () => {
             test("finite", () => {
                 expect(
-                    new Decimal128("42").subtract(posInf).toString()
+                    Decimal128.subtract(new Decimal128("42"), posInf).toString()
                 ).toStrictEqual("-Infinity");
             });
             test("positive infinity", () => {
-                expect(posInf.subtract(posInf).toString()).toStrictEqual("NaN");
+                expect(
+                    Decimal128.subtract(posInf, posInf).toString()
+                ).toStrictEqual("NaN");
             });
             test("negative infinity", () => {
-                expect(posInf.subtract(negInf).toString()).toStrictEqual(
-                    "Infinity"
-                );
+                expect(
+                    Decimal128.subtract(posInf, negInf).toString()
+                ).toStrictEqual("Infinity");
             });
         });
         describe("negative infinity", () => {
             test("finite", () => {
                 expect(
-                    new Decimal128("42").subtract(negInf).toString()
+                    Decimal128.subtract(new Decimal128("42"), negInf).toString()
                 ).toStrictEqual("Infinity");
             });
             test("positive infinity", () => {
-                expect(negInf.subtract(posInf).toString()).toStrictEqual(
-                    "-Infinity"
-                );
+                expect(
+                    Decimal128.subtract(negInf, posInf).toString()
+                ).toStrictEqual("-Infinity");
             });
             test("negative infinity", () => {
-                expect(negInf.subtract(negInf).toString()).toStrictEqual("NaN");
+                expect(
+                    Decimal128.subtract(negInf, negInf).toString()
+                ).toStrictEqual("NaN");
             });
         });
     });
@@ -136,17 +159,26 @@ describe("infinity", () => {
 describe("examples from the General Decimal Arithmetic specification", () => {
     test("example one", () => {
         expect(
-            new Decimal128("1.3").subtract(new Decimal128("1.07")).toString()
+            Decimal128.subtract(
+                new Decimal128("1.3"),
+                new Decimal128("1.07")
+            ).toString()
         ).toStrictEqual("0.23");
     });
     test("example two", () => {
         expect(
-            new Decimal128("1.3").subtract(new Decimal128("1.30")).toString()
+            Decimal128.subtract(
+                new Decimal128("1.3"),
+                new Decimal128("1.30")
+            ).toString()
         ).toStrictEqual("0.00");
     });
     test("example three", () => {
         expect(
-            new Decimal128("1.3").subtract(new Decimal128("2.07")).toString()
+            Decimal128.subtract(
+                new Decimal128("1.3"),
+                new Decimal128("2.07")
+            ).toString()
         ).toStrictEqual("-0.77");
     });
 });


### PR DESCRIPTION
This matches the built-in operators for `+`, `*`, `-`, `/`, and `%`.