### PR TITLE
Remove normalization option in constructor in favor of normalizing in `toString`

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -22,7 +22,7 @@ jobs:
             - name: lint
               run: npm run lint
             - name: compile typescript
-              run: tsc
+              run: npx tsc
             - name: test
               run: npm run test
             - name: generate coverage

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,3 +1,4 @@
+---
 on: push
 name: CI
 jobs:

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ Think of this package as providing, basically, arbitrary-precision decimal numbe
 
 #### Serialized values normalized by default
 
-Decimal128 is a universe of **unnormalized** values. In the Decimal128 world, `1.2` and `1.20` are _distinct_ values. There's good reason for adopting such an approach, and has some benefits. But there can be surprises when working with non-normal values. This package supports IEEE 754 Decimal128, but it also aims to minimize surprises. In IEEE 754 Decimal128, if one adds, say, 1.2 and 3.8, the result is 5.0, not 5. (Again, those are *distinct* values in IEEE 754 Decimal128.) Reproducing that example with this package, one has
+Decimal128 is a universe of **unnormalized** values. In the Decimal128 world, `1.2` and `1.20` are _distinct_ values. There's good reason for adopting such an approach, and has some benefits. But there can be surprises when working with non-normal values. This package supports IEEE 754 Decimal128, but it also aims to minimize surprises. In IEEE 754 Decimal128, if one adds, say, 1.2 and 3.8, the result is 5.0, not 5. (Again, those are _distinct_ values in IEEE 754 Decimal128.) Reproducing that example with this package, one has
 
 ```javascript
-new Decimal128("1.2").add(new Decimal128("3.8")).toString() // "5"
+new Decimal128("1.2").add(new Decimal128("3.8")).toString(); // "5"
 ```
 
 One can switch off normalization by setting the `normalize` option to `false` in `toString`, like this:
 
 ```javascript
-new Decimal128("1.2").add(new Decimal128("3.8")).toString({ normalize: false }) // "5.0"
+new Decimal128("1.2").add(new Decimal128("3.8")).toString({ normalize: false }); // "5.0"
 ```

--- a/tests/add.test.js
+++ b/tests/add.test.js
@@ -117,6 +117,16 @@ describe("addition", () => {
     });
 });
 
+describe("specify rounding mode", () => {
+    test("truncate rounding mode", () => {
+        expect(
+            new Decimal128("1234567890123456789012345678901234")
+                .add(new Decimal128("0.5"), { roundingMode: "trunc" })
+                .toString()
+        ).toStrictEqual("1234567890123456789012345678901234");
+    });
+});
+
 describe("examples from the General Decimal Arithmetic specification", () => {
     test("example one", () => {
         expect(


### PR DESCRIPTION
Also, clean up README and restore (rounding) options to arithmetic operations.