### PR TITLE
Adding types in order to be able to load package into typescript project

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
             "url": "https://opensource.org/license/bsd-2-clause/"
         }
     ],
+    "types": "./src/decimal128.d.mjs",
     "exports": {
         ".": "./src/decimal128.mjs"
     }


### PR DESCRIPTION
Without `types` specification in the `package.json`, the typescript would complain that it could not find declarations