### PR TITLE
chore: build project to emit cjs and esm using rollup 

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -22,7 +22,7 @@ jobs:
             - name: lint
               run: npm run lint
             - name: compile typescript
-              run: npx tsc
+              run: npm run build && npx tsc
             - name: test
               run: npm run test
             - name: generate coverage

--- a/examples/bill.ts
+++ b/examples/bill.ts
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 const zero = new Decimal128("0");
 const one = new Decimal128("1");

--- a/examples/floor.mts
+++ b/examples/floor.mts
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 function floor(d: Decimal128): Decimal128 {
     return d.round(0, "floor");

--- a/examples/mortgage.ts
+++ b/examples/mortgage.ts
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 import { pow } from "./pow.mjs";
 
 const one = new Decimal128("1");

--- a/examples/normalize.mts
+++ b/examples/normalize.mts
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 function normalize(d: Decimal128): string {
     // Decimal128 object

--- a/examples/pow.mts
+++ b/examples/pow.mts
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 function pow(a: Decimal128, b: number): Decimal128 {
     let result = a;

--- a/examples/round.js
+++ b/examples/round.js
@@ -2,7 +2,7 @@
 
 // Examples from the Intl.NumberFormat spec
 
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 let minusOnePointFive = new Decimal128("-1.5");
 let zeroPointFour = new Decimal128("0.4");

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,15 @@
             "version": "12.2.0",
             "license": "ISC",
             "devDependencies": {
-                "@types/jest": "^29.5.1",
+                "@rollup/plugin-typescript": "^11.1.6",
+                "@types/jest": "^29.5.12",
                 "c8": "^9.1.0",
-                "jest": "^29.5.0",
+                "jest": "^29.7.0",
                 "jest-light-runner": "^0.6.0",
                 "prettier": "^3.0.0",
-                "ts-jest": "^29.1.0",
+                "rollup": "^4.14.1",
+                "ts-jest": "^29.1.2",
+                "tslib": "^2.6.2",
                 "typescript": "^5.1.3"
             }
         },
@@ -32,87 +35,16 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.22.13",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+            "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.22.13",
-                "chalk": "^2.4.2"
+                "@babel/highlight": "^7.24.2",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "dev": true
-        },
-        "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/@babel/compat-data": {
@@ -161,14 +93,14 @@
             "dev": true
         },
         "node_modules/@babel/generator": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
-            "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
+            "integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.15",
-                "@jridgewell/gen-mapping": "^0.3.2",
-                "@jridgewell/trace-mapping": "^0.3.17",
+                "@babel/types": "^7.24.0",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
             },
             "engines": {
@@ -192,22 +124,22 @@
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-            "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-            "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -290,18 +222,18 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+            "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
-            "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -331,14 +263,15 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.22.13",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
-            "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+            "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -416,9 +349,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.22.16",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-            "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
+            "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -619,20 +552,20 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.22.17",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.17.tgz",
-            "integrity": "sha512-xK4Uwm0JnAMvxYZxOVecss85WxTEIbTa7bnGyf/+EgCL5Zt3U7htUpEOWv9detPlamGKuRzCqw74xVglDWpPdg==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
+            "integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/generator": "^7.22.15",
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
+                "@babel/code-frame": "^7.24.1",
+                "@babel/generator": "^7.24.1",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.22.16",
-                "@babel/types": "^7.22.17",
-                "debug": "^4.1.0",
+                "@babel/parser": "^7.24.1",
+                "@babel/types": "^7.24.0",
+                "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -640,13 +573,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.22.17",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.17.tgz",
-            "integrity": "sha512-YSQPHLFtQNE5xN9tHuZnzu8vPr61wVTBZdfv1meex1NBosa4iT05k/Jw06ddJugi4bk7The/oSwQGFcksmEJQg==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+            "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.15",
+                "@babel/helper-string-parser": "^7.23.4",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -1015,14 +948,14 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
@@ -1038,9 +971,9 @@
             }
         },
         "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true,
             "engines": {
                 "node": ">=6.0.0"
@@ -1053,9 +986,9 @@
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-            "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -1116,6 +1049,249 @@
             "funding": {
                 "url": "https://opencollective.com/unts"
             }
+        },
+        "node_modules/@rollup/plugin-typescript": {
+            "version": "11.1.6",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz",
+            "integrity": "sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.1.0",
+                "resolve": "^1.22.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.14.0||^3.0.0||^4.0.0",
+                "tslib": "*",
+                "typescript": ">=3.7.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                },
+                "tslib": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+            "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.1.tgz",
+            "integrity": "sha512-fH8/o8nSUek8ceQnT7K4EQbSiV7jgkHq81m9lWZFIXjJ7lJzpWXbQFpT/Zh6OZYnpFykvzC3fbEvEAFZu03dPA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.1.tgz",
+            "integrity": "sha512-Y/9OHLjzkunF+KGEoJr3heiD5X9OLa8sbT1lm0NYeKyaM3oMhhQFvPB0bNZYJwlq93j8Z6wSxh9+cyKQaxS7PQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.1.tgz",
+            "integrity": "sha512-+kecg3FY84WadgcuSVm6llrABOdQAEbNdnpi5X3UwWiFVhZIZvKgGrF7kmLguvxHNQy+UuRV66cLVl3S+Rkt+Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.1.tgz",
+            "integrity": "sha512-2pYRzEjVqq2TB/UNv47BV/8vQiXkFGVmPFwJb+1E0IFFZbIX8/jo1olxqqMbo6xCXf8kabANhp5bzCij2tFLUA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.1.tgz",
+            "integrity": "sha512-mS6wQ6Do6/wmrF9aTFVpIJ3/IDXhg1EZcQFYHZLHqw6AzMBjTHWnCG35HxSqUNphh0EHqSM6wRTT8HsL1C0x5g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.1.tgz",
+            "integrity": "sha512-p9rGKYkHdFMzhckOTFubfxgyIO1vw//7IIjBBRVzyZebWlzRLeNhqxuSaZ7kCEKVkm/kuC9fVRW9HkC/zNRG2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.1.tgz",
+            "integrity": "sha512-nDY6Yz5xS/Y4M2i9JLQd3Rofh5OR8Bn8qe3Mv/qCVpHFlwtZSBYSPaU4mrGazWkXrdQ98GB//H0BirGR/SKFSw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.1.tgz",
+            "integrity": "sha512-im7HE4VBL+aDswvcmfx88Mp1soqL9OBsdDBU8NqDEYtkri0qV0THhQsvZtZeNNlLeCUQ16PZyv7cqutjDF35qw==",
+            "cpu": [
+                "ppc64le"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.1.tgz",
+            "integrity": "sha512-RWdiHuAxWmzPJgaHJdpvUUlDz8sdQz4P2uv367T2JocdDa98iRw2UjIJ4QxSyt077mXZT2X6pKfT2iYtVEvOFw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.1.tgz",
+            "integrity": "sha512-VMgaGQ5zRX6ZqV/fas65/sUGc9cPmsntq2FiGmayW9KMNfWVG/j0BAqImvU4KTeOOgYSf1F+k6at1UfNONuNjA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.1.tgz",
+            "integrity": "sha512-9Q7DGjZN+hTdJomaQ3Iub4m6VPu1r94bmK2z3UeWP3dGUecRC54tmVu9vKHTm1bOt3ASoYtEz6JSRLFzrysKlA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.1.tgz",
+            "integrity": "sha512-JNEG/Ti55413SsreTguSx0LOVKX902OfXIKVg+TCXO6Gjans/k9O6ww9q3oLGjNDaTLxM+IHFMeXy/0RXL5R/g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.1.tgz",
+            "integrity": "sha512-ryS22I9y0mumlLNwDFYZRDFLwWh3aKaC72CWjFcFvxK0U6v/mOkM5Up1bTbCRAhv3kEIwW2ajROegCIQViUCeA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.1.tgz",
+            "integrity": "sha512-TdloItiGk+T0mTxKx7Hp279xy30LspMso+GzQvV2maYePMAWdmrzqSNZhUpPj3CGw12aGj57I026PgLCTu8CGg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.1.tgz",
+            "integrity": "sha512-wQGI+LY/Py20zdUPq+XCem7JcPOyzIJBm3dli+56DJsQOHbnXZFEwgmnC6el1TPAfC8lBT3m+z69RmLykNUbew==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
@@ -1181,6 +1357,12 @@
             "dependencies": {
                 "@babel/types": "^7.20.7"
             }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+            "dev": true
         },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.6",
@@ -2024,6 +2206,12 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
         },
         "node_modules/execa": {
             "version": "5.1.1",
@@ -4509,6 +4697,40 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/rollup": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
+            "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "1.0.5"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.14.1",
+                "@rollup/rollup-android-arm64": "4.14.1",
+                "@rollup/rollup-darwin-arm64": "4.14.1",
+                "@rollup/rollup-darwin-x64": "4.14.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.14.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.14.1",
+                "@rollup/rollup-linux-arm64-musl": "4.14.1",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.14.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.14.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.14.1",
+                "@rollup/rollup-linux-x64-gnu": "4.14.1",
+                "@rollup/rollup-linux-x64-musl": "4.14.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.14.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.14.1",
+                "@rollup/rollup-win32-x64-msvc": "4.14.1",
+                "fsevents": "~2.3.2"
+            }
+        },
         "node_modules/run-applescript": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
@@ -5108,71 +5330,13 @@
             }
         },
         "@babel/code-frame": {
-            "version": "7.22.13",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+            "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.22.13",
-                "chalk": "^2.4.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-                    "dev": true
-                },
-                "escape-string-regexp": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                    "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
+                "@babel/highlight": "^7.24.2",
+                "picocolors": "^1.0.0"
             }
         },
         "@babel/compat-data": {
@@ -5213,14 +5377,14 @@
             }
         },
         "@babel/generator": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
-            "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
+            "integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.22.15",
-                "@jridgewell/gen-mapping": "^0.3.2",
-                "@jridgewell/trace-mapping": "^0.3.17",
+                "@babel/types": "^7.24.0",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
             }
         },
@@ -5238,19 +5402,19 @@
             }
         },
         "@babel/helper-environment-visitor": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-            "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
             "dev": true
         },
         "@babel/helper-function-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-            "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
             }
         },
         "@babel/helper-hoist-variables": {
@@ -5309,15 +5473,15 @@
             }
         },
         "@babel/helper-string-parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+            "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
             "dev": true
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
-            "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
             "dev": true
         },
         "@babel/helper-validator-option": {
@@ -5338,14 +5502,15 @@
             }
         },
         "@babel/highlight": {
-            "version": "7.22.13",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
-            "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+            "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5407,9 +5572,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.22.16",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-            "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
+            "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
             "dev": true
         },
         "@babel/plugin-syntax-async-generators": {
@@ -5550,31 +5715,31 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.22.17",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.17.tgz",
-            "integrity": "sha512-xK4Uwm0JnAMvxYZxOVecss85WxTEIbTa7bnGyf/+EgCL5Zt3U7htUpEOWv9detPlamGKuRzCqw74xVglDWpPdg==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
+            "integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/generator": "^7.22.15",
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
+                "@babel/code-frame": "^7.24.1",
+                "@babel/generator": "^7.24.1",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.22.16",
-                "@babel/types": "^7.22.17",
-                "debug": "^4.1.0",
+                "@babel/parser": "^7.24.1",
+                "@babel/types": "^7.24.0",
+                "debug": "^4.3.1",
                 "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.22.17",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.17.tgz",
-            "integrity": "sha512-YSQPHLFtQNE5xN9tHuZnzu8vPr61wVTBZdfv1meex1NBosa4iT05k/Jw06ddJugi4bk7The/oSwQGFcksmEJQg==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+            "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
             "dev": true,
             "requires": {
-                "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.15",
+                "@babel/helper-string-parser": "^7.23.4",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -5863,14 +6028,14 @@
             }
         },
         "@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dev": true,
             "requires": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
         "@jridgewell/resolve-uri": {
@@ -5880,9 +6045,9 @@
             "dev": true
         },
         "@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true
         },
         "@jridgewell/sourcemap-codec": {
@@ -5892,9 +6057,9 @@
             "dev": true
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-            "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -5940,6 +6105,132 @@
                 "picocolors": "^1.0.0",
                 "tslib": "^2.6.0"
             }
+        },
+        "@rollup/plugin-typescript": {
+            "version": "11.1.6",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz",
+            "integrity": "sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==",
+            "dev": true,
+            "requires": {
+                "@rollup/pluginutils": "^5.1.0",
+                "resolve": "^1.22.1"
+            }
+        },
+        "@rollup/pluginutils": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+            "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+            "dev": true,
+            "requires": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^2.3.1"
+            }
+        },
+        "@rollup/rollup-android-arm-eabi": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.1.tgz",
+            "integrity": "sha512-fH8/o8nSUek8ceQnT7K4EQbSiV7jgkHq81m9lWZFIXjJ7lJzpWXbQFpT/Zh6OZYnpFykvzC3fbEvEAFZu03dPA==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-android-arm64": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.1.tgz",
+            "integrity": "sha512-Y/9OHLjzkunF+KGEoJr3heiD5X9OLa8sbT1lm0NYeKyaM3oMhhQFvPB0bNZYJwlq93j8Z6wSxh9+cyKQaxS7PQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-darwin-arm64": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.1.tgz",
+            "integrity": "sha512-+kecg3FY84WadgcuSVm6llrABOdQAEbNdnpi5X3UwWiFVhZIZvKgGrF7kmLguvxHNQy+UuRV66cLVl3S+Rkt+Q==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-darwin-x64": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.1.tgz",
+            "integrity": "sha512-2pYRzEjVqq2TB/UNv47BV/8vQiXkFGVmPFwJb+1E0IFFZbIX8/jo1olxqqMbo6xCXf8kabANhp5bzCij2tFLUA==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.1.tgz",
+            "integrity": "sha512-mS6wQ6Do6/wmrF9aTFVpIJ3/IDXhg1EZcQFYHZLHqw6AzMBjTHWnCG35HxSqUNphh0EHqSM6wRTT8HsL1C0x5g==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.1.tgz",
+            "integrity": "sha512-p9rGKYkHdFMzhckOTFubfxgyIO1vw//7IIjBBRVzyZebWlzRLeNhqxuSaZ7kCEKVkm/kuC9fVRW9HkC/zNRG2w==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-arm64-musl": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.1.tgz",
+            "integrity": "sha512-nDY6Yz5xS/Y4M2i9JLQd3Rofh5OR8Bn8qe3Mv/qCVpHFlwtZSBYSPaU4mrGazWkXrdQ98GB//H0BirGR/SKFSw==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-powerpc64le-gnu": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.1.tgz",
+            "integrity": "sha512-im7HE4VBL+aDswvcmfx88Mp1soqL9OBsdDBU8NqDEYtkri0qV0THhQsvZtZeNNlLeCUQ16PZyv7cqutjDF35qw==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.1.tgz",
+            "integrity": "sha512-RWdiHuAxWmzPJgaHJdpvUUlDz8sdQz4P2uv367T2JocdDa98iRw2UjIJ4QxSyt077mXZT2X6pKfT2iYtVEvOFw==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.1.tgz",
+            "integrity": "sha512-VMgaGQ5zRX6ZqV/fas65/sUGc9cPmsntq2FiGmayW9KMNfWVG/j0BAqImvU4KTeOOgYSf1F+k6at1UfNONuNjA==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-x64-gnu": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.1.tgz",
+            "integrity": "sha512-9Q7DGjZN+hTdJomaQ3Iub4m6VPu1r94bmK2z3UeWP3dGUecRC54tmVu9vKHTm1bOt3ASoYtEz6JSRLFzrysKlA==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-x64-musl": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.1.tgz",
+            "integrity": "sha512-JNEG/Ti55413SsreTguSx0LOVKX902OfXIKVg+TCXO6Gjans/k9O6ww9q3oLGjNDaTLxM+IHFMeXy/0RXL5R/g==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.1.tgz",
+            "integrity": "sha512-ryS22I9y0mumlLNwDFYZRDFLwWh3aKaC72CWjFcFvxK0U6v/mOkM5Up1bTbCRAhv3kEIwW2ajROegCIQViUCeA==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.1.tgz",
+            "integrity": "sha512-TdloItiGk+T0mTxKx7Hp279xy30LspMso+GzQvV2maYePMAWdmrzqSNZhUpPj3CGw12aGj57I026PgLCTu8CGg==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-win32-x64-msvc": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.1.tgz",
+            "integrity": "sha512-wQGI+LY/Py20zdUPq+XCem7JcPOyzIJBm3dli+56DJsQOHbnXZFEwgmnC6el1TPAfC8lBT3m+z69RmLykNUbew==",
+            "dev": true,
+            "optional": true
         },
         "@sinclair/typebox": {
             "version": "0.27.8",
@@ -6005,6 +6296,12 @@
             "requires": {
                 "@babel/types": "^7.20.7"
             }
+        },
+        "@types/estree": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+            "dev": true
         },
         "@types/graceful-fs": {
             "version": "4.1.6",
@@ -6602,6 +6899,12 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
             "dev": true
         },
         "execa": {
@@ -8450,6 +8753,31 @@
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true
+        },
+        "rollup": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
+            "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
+            "dev": true,
+            "requires": {
+                "@rollup/rollup-android-arm-eabi": "4.14.1",
+                "@rollup/rollup-android-arm64": "4.14.1",
+                "@rollup/rollup-darwin-arm64": "4.14.1",
+                "@rollup/rollup-darwin-x64": "4.14.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.14.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.14.1",
+                "@rollup/rollup-linux-arm64-musl": "4.14.1",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.14.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.14.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.14.1",
+                "@rollup/rollup-linux-x64-gnu": "4.14.1",
+                "@rollup/rollup-linux-x64-musl": "4.14.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.14.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.14.1",
+                "@rollup/rollup-win32-x64-msvc": "4.14.1",
+                "@types/estree": "1.0.5",
+                "fsevents": "~2.3.2"
+            }
         },
         "run-applescript": {
             "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,31 @@
 {
     "name": "decimal128",
     "version": "12.2.0",
-    "main": "src/decimal128.js",
+    "main": "dist/decimal128.cjs",
+    "module": "dist/decimal128.mjs",
+    "typings": "dist/decimal128.d.ts",
+    "exports": {
+        ".": {
+            "import": "./dist/decimal128.mjs",
+            "require": "./dist/decimal128.cjs",
+            "types": "./dist/decimal128.d.ts"
+        }
+    },
     "type": "module",
     "description": "Partial implementation of IEEE 754 Decimal128 decimal floating-point numbers",
     "directories": {
         "test": "tests"
     },
+    "files": [
+        "dist"
+    ],
     "repository": {
         "type": "git",
         "url": "https://github.com/jessealama/decimal128.js.git"
     },
     "sideEffects": false,
     "scripts": {
+        "build": "rollup -c",
         "test": "jest",
         "format": "prettier . --write",
         "lint": "prettier . --check",
@@ -34,12 +47,15 @@
     "author": "Jesse Alama <jesse@igalia.com>",
     "license": "ISC",
     "devDependencies": {
-        "@types/jest": "^29.5.1",
+        "@rollup/plugin-typescript": "^11.1.6",
+        "@types/jest": "^29.5.12",
         "c8": "^9.1.0",
-        "jest": "^29.5.0",
+        "jest": "^29.7.0",
         "jest-light-runner": "^0.6.0",
         "prettier": "^3.0.0",
-        "ts-jest": "^29.1.0",
+        "rollup": "^4.14.1",
+        "ts-jest": "^29.1.2",
+        "tslib": "^2.6.2",
         "typescript": "^5.1.3"
     },
     "licenses": [
@@ -47,8 +63,5 @@
             "type": "BSD-2-Clause",
             "url": "https://opensource.org/license/bsd-2-clause/"
         }
-    ],
-    "exports": {
-        ".": "./src/decimal128.mjs"
-    }
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
     "name": "decimal128",
     "version": "12.2.0",
-    "main": "dist/decimal128.cjs",
-    "module": "dist/decimal128.mjs",
-    "typings": "dist/decimal128.d.ts",
+    "main": "dist/cjs/decimal128.cjs",
+    "module": "dist/esm/decimal128.mjs",
+    "typings": "dist/esm/decimal128.d.ts",
     "exports": {
         ".": {
-            "import": "./dist/decimal128.mjs",
-            "require": "./dist/decimal128.cjs",
-            "types": "./dist/decimal128.d.ts"
+            "import": "./dist/esm/decimal128.mjs",
+            "require": "./dist/cjs/decimal128.cjs",
+            "types": "./dist/esm/decimal128.d.ts"
         }
     },
     "type": "module",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,37 +2,36 @@
 import typescript from "@rollup/plugin-typescript";
 
 /**
- * @type { import("rollup").OutputOptions }
+ * @param {'esm' | 'cjs'} format
+ * @returns { import("rollup").RollupOptions }
  */
-const commonOutput = {
-    sourcemap: true,
-    interop: "esModule",
+const createConfig = (format) => {
+    const extension = format === "esm" ? "mjs" : "cjs";
+    return {
+        input: "src/decimal128.mts",
+        output: [
+            {
+                sourcemap: true,
+                interop: "esModule",
+                preserveModules: true,
+                dir: `./dist/${format}`,
+                format: format,
+                entryFileNames: `[name].${extension}`,
+            },
+        ],
+        plugins: [
+            typescript({
+                tsconfig: "tsconfig.build.json",
+                outDir: `dist/${format}`,
+                sourceMap: false,
+            }),
+        ],
+    };
 };
 
 /**
- * @type { import("rollup").RollupOptions }
+ * @type { import("rollup").RollupOptions[] }
  */
-const config = {
-    input: "src/decimal128.mts",
-    output: [
-        {
-            ...commonOutput,
-            file: "./dist/decimal128.mjs",
-            format: "esm",
-        },
-        {
-            ...commonOutput,
-            file: "./dist/decimal128.cjs",
-            format: "cjs",
-        },
-    ],
-    plugins: [
-        typescript({
-            tsconfig: "tsconfig.build.json",
-            outDir: "dist",
-            sourceMap: false,
-        }),
-    ],
-};
+const config = [createConfig("esm"), createConfig("cjs")];
 
 export default config;

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,0 +1,38 @@
+// @ts-check
+import typescript from "@rollup/plugin-typescript";
+
+/**
+ * @type { import("rollup").OutputOptions }
+ */
+const commonOutput = {
+    sourcemap: true,
+    interop: "esModule",
+};
+
+/**
+ * @type { import("rollup").RollupOptions }
+ */
+const config = {
+    input: "src/decimal128.mts",
+    output: [
+        {
+            ...commonOutput,
+            file: "./dist/decimal128.mjs",
+            format: "esm",
+        },
+        {
+            ...commonOutput,
+            file: "./dist/decimal128.cjs",
+            format: "cjs",
+        },
+    ],
+    plugins: [
+        typescript({
+            tsconfig: "tsconfig.build.json",
+            outDir: "dist",
+            sourceMap: false,
+        }),
+    ],
+};
+
+export default config;

--- a/tests/abs.test.js
+++ b/tests/abs.test.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
 const bigDigits = "9".repeat(MAX_SIGNIFICANT_DIGITS);

--- a/tests/add.test.js
+++ b/tests/add.test.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
 const bigDigits = "9".repeat(MAX_SIGNIFICANT_DIGITS);

--- a/tests/common.test.js
+++ b/tests/common.test.js
@@ -1,4 +1,4 @@
-import { countSignificantDigits } from "../src/common.mjs";
+import { countSignificantDigits } from "../dist/esm/common.mjs";
 
 describe("significant digits", () => {
     test("basic example", () => {

--- a/tests/constructor.test.js
+++ b/tests/constructor.test.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
 

--- a/tests/divide.test.js
+++ b/tests/divide.test.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 describe("division", () => {
     test("simple example", () => {

--- a/tests/equals.test.js
+++ b/tests/equals.test.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
 const nan = new Decimal128("NaN");

--- a/tests/lessthan.test.js
+++ b/tests/lessthan.test.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
 const nan = new Decimal128("NaN");

--- a/tests/multiply.test.js
+++ b/tests/multiply.test.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 const examples = [
     ["123.456", "789.789", "97504.190784"],

--- a/tests/neg.test.js
+++ b/tests/neg.test.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
 const bigDigits = "9".repeat(MAX_SIGNIFICANT_DIGITS);

--- a/tests/rational.test.js
+++ b/tests/rational.test.js
@@ -1,4 +1,4 @@
-import { Rational } from "../src/rational.mjs";
+import { Rational } from "../dist/esm/rational.mjs";
 describe("constructor", () => {
     test("cannot divide by zero", () => {
         expect(() => new Rational(1n, 0n)).toThrow(RangeError);

--- a/tests/remainder.test.js
+++ b/tests/remainder.test.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 const a = "4.1";
 const b = "1.25";

--- a/tests/round.test.js
+++ b/tests/round.test.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 import * as string_decoder from "string_decoder";
 import { expectDecimal128 } from "./util.js";
 

--- a/tests/subtract.test.js
+++ b/tests/subtract.test.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 import { expectDecimal128 } from "./util.js";
 
 const MAX_SIGNIFICANT_DIGITS = 34;

--- a/tests/tostring.test.js
+++ b/tests/tostring.test.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 import { expectDecimal128 } from "./util.js";
 
 describe("NaN", () => {

--- a/tests/util.js
+++ b/tests/util.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 export function expectDecimal128(a, b) {
     let lhs = a instanceof Decimal128 ? a.toString({ normalize: false }) : a;

--- a/tests/valueof.test.js
+++ b/tests/valueof.test.js
@@ -1,4 +1,4 @@
-import { Decimal128 } from "../src/decimal128.mjs";
+import { Decimal128 } from "../dist/esm/decimal128.mjs";
 
 describe("valueOf", () => {
     test("throws unconditionally", () => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["./src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,9 +27,9 @@
         // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
         /* Modules */
-        "module": "nodenext" /* Specify what module code is generated. */,
+        "module": "NodeNext" /* Specify what module code is generated. */,
         // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-        "moduleResolution": "nodenext" /* Specify how TypeScript looks up a file from a given module specifier. */,
+        "moduleResolution": "NodeNext" /* Specify how TypeScript looks up a file from a given module specifier. */,
         // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
         // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
         // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
Edit 1: Updated base on commit [759f5b7](https://github.com/jessealama/decimal128/commit/759f5b7910d6d46982e1f8a329a2fd7ef9b91a1a)

## Summary
⚠ BREAKING CHANGE: distribution layout has been significantly changed

Support both `cjs` and `mjs` output using rollup.

The package.json now includes the modern `exports` field and the legacy `main`, `modules` and `typings` fields to ensure compatibiilty with older Node runtime / bundler

## Related to
Related to #61

## Motivation

To resolve #61

## How is this tested

### Fixtures for the different environments

> ✔ retested for 759f5b7910d6d46982e1f8a329a2fd7ef9b91a1a (code identical with latest @ d4c890941a372f6bea8c2c36d899a4c8f6ebd0c8)



I have created a repository hosting the 4 test environments below here: https://github.com/amoshydra/repro-jessealama-decimal128/tree/ref-759f5b791

- browser importing mjs
- nodejs [type="module"] importing mjs
- nodejs [type="commonjs"] importing cjs
- bundler (vite --> rollup / esbuild) importing mjs

| browser mjs | nodejs cjs | nodejs mjs | vite mjs|
| -- | -- | -- | -- |
![browser-mjs](https://github.com/jessealama/decimal128/assets/8733840/33622317-fd45-4bfb-ba89-a60820e6cd11) | ![nodejs-cjs](https://github.com/jessealama/decimal128/assets/8733840/c23f343e-18e4-4b27-be9e-b81c2dcc40b3) | ![nodejs-mjs](https://github.com/jessealama/decimal128/assets/8733840/e4e8ce3b-0335-49d7-adef-85a6e29b65d2) | ![vite-mjs](https://github.com/jessealama/decimal128/assets/8733840/7ef2e38d-ef71-4411-9141-e7e9a12306fb)


## Layout change in npm package

This layout change does not really affect the consumer using a bundler, TypeScript or NodeJS as they will continue to import the package via one of the following ways:

```js
// esm
import { Decimal128 } from "decimal128";
// cjs
const { Decimal128 } = require("decimal128");
```

#### Before
Files are exported from `src`
```
src
├── common.d.mts
├── common.mjs
├── common.mts
├── decimal128.d.mts
├── decimal128.mjs
├── decimal128.mts
├── rational.d.mts
├── rational.mjs
└── rational.mts
```

#### After
Files are exported from `dist`

```
dist
├── cjs
│   ├── common.cjs
│   ├── common.cjs.map
│   ├── common.d.mts
│   ├── decimal128.cjs
│   ├── decimal128.cjs.map
│   ├── decimal128.d.mts
│   ├── rational.cjs
│   ├── rational.cjs.map
│   └── rational.d.mts
└── esm
    ├── common.d.mts
    ├── common.mjs
    ├── common.mjs.map
    ├── decimal128.d.mts
    ├── decimal128.mjs
    ├── decimal128.mjs.map
    ├── rational.d.mts
    ├── rational.mjs
    └── rational.mjs.map
```