### PR TITLE
fix: remove yarn from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
             "name": "decimal128",
             "version": "11.2.0",
             "license": "ISC",
-            "dependencies": {
-                "yarn": "^1.22.21"
-            },
             "devDependencies": {
                 "@types/jest": "^29.5.1",
                 "c8": "^9.1.0",
@@ -5086,19 +5083,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/yarn": {
-            "version": "1.22.21",
-            "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.21.tgz",
-            "integrity": "sha512-ynXaJsADJ9JiZ84zU25XkPGOvVMmZ5b7tmTSpKURYwgELdjucAOydqIOrOfTxVYcNXe91xvLZwcRh68SR3liCg==",
-            "hasInstallScript": true,
-            "bin": {
-                "yarn": "bin/yarn.js",
-                "yarnpkg": "bin/yarn.js"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -8850,11 +8834,6 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true
-        },
-        "yarn": {
-            "version": "1.22.21",
-            "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.21.tgz",
-            "integrity": "sha512-ynXaJsADJ9JiZ84zU25XkPGOvVMmZ5b7tmTSpKURYwgELdjucAOydqIOrOfTxVYcNXe91xvLZwcRh68SR3liCg=="
         },
         "yocto-queue": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "sideEffects": false,
     "scripts": {
         "test": "jest",
-        "format": "yarn prettier . --write",
-        "lint": "yarn prettier . --check",
+        "format": "prettier . --write",
+        "lint": "prettier . --check",
         "coverage": "npx c8 npx jest"
     },
     "prettier": {

--- a/package.json
+++ b/package.json
@@ -50,8 +50,5 @@
     ],
     "exports": {
         ".": "./src/decimal128.mjs"
-    },
-    "dependencies": {
-        "yarn": "^1.22.21"
     }
 }


### PR DESCRIPTION
# Summary

1. remove yarn from dependencies
2. let npm-script resolve prettier (removing `yarn`) for `lint` and `format` task

# Related

To resolve #97

# Motivation

To prevent yarn from being bundled into consumer's `node_modules`

# How is this tested?

- `yarn` is not used anywhere in this repository
- ~~no part of the code in relies on `yarn`~~ (`format` and `lint` currently relies on `yarn`)
    - tested in https://github.com/jessealama/decimal128/pull/98#issuecomment-2047878939