### PR TITLE
Remove ability to compare decimals as digit strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- The `normalize` option for `lessThan` and `equals` has been removed. The comparison is now always done on the mathematical value.
+-   The `normalize` option for `lessThan` and `equals` has been removed. The comparison is now always done on the mathematical value.
 
 ## [11.2.0] - 2024-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [12.0.0] - 2024-04-10
+
+### Removed
+
+- The `normalize` option for `lessThan` and `equals` has been removed. The comparison is now always done on the mathematical value.
+
 ## [11.2.0] - 2024-03-29
 
 ### Changed

--- a/src/decimal128.mts
+++ b/src/decimal128.mts
@@ -975,22 +975,6 @@ function ensureFullySpecifiedToStringOptions(
     return opts;
 }
 
-function ensureFullySpecifiedCmpOptions(
-    options?: CmpOptions
-): FullySpecifiedCmpOptions {
-    let opts = { ...DEFAULT_CMP_OPTIONS };
-
-    if (undefined === options) {
-        return opts;
-    }
-
-    if ("boolean" === typeof options.normalize) {
-        opts.total = options.normalize;
-    }
-
-    return opts;
-}
-
 function toRational(isNegative: boolean, sg: bigint, exp: number): Rational {
     if (1n === sg) {
         // power of ten

--- a/src/decimal128.mts
+++ b/src/decimal128.mts
@@ -675,7 +675,7 @@ function handleDecimalNotation(
     }
 
     if ("-." === withoutUnderscores) {
-        throw new SyntaxError("Lone minus sign and period anot permitted");
+        throw new SyntaxError("Lone minus sign and period not permitted");
     }
 
     let isNegative = !!withoutUnderscores.match(/^-/);
@@ -893,18 +893,6 @@ const DEFAULT_TOSTRING_OPTIONS: FullySpecifiedToStringOptions = Object.freeze({
     format: "decimal",
     numDecimalDigits: undefined,
     normalize: true,
-});
-
-interface CmpOptions {
-    normalize?: boolean;
-}
-
-interface FullySpecifiedCmpOptions {
-    total: boolean;
-}
-
-const DEFAULT_CMP_OPTIONS: FullySpecifiedCmpOptions = Object.freeze({
-    total: false, // compare by numeric value (ignore trailing zeroes, treat NaN as not-a-number, for a change)
 });
 
 function ensureFullySpecifiedConstructorOptions(

--- a/src/decimal128.mts
+++ b/src/decimal128.mts
@@ -1190,28 +1190,10 @@ export class Decimal128 {
      * + 1 otherwise.
      *
      * @param x
-     * @param opts
      */
-    private cmp(x: Decimal128, opts?: CmpOptions): -1 | 0 | 1 | undefined {
-        let options = ensureFullySpecifiedCmpOptions(opts);
-
-        if (this.isNaN) {
-            if (options.total) {
-                if (x.isNaN) {
-                    return 0;
-                }
-                return 1;
-            }
-
-            return undefined;
-        }
-
-        if (x.isNaN) {
-            if (options.total) {
-                return -1;
-            }
-
-            return undefined;
+    private cmp(x: Decimal128): -1 | 0 | 1 {
+        if (this.isNaN || x.isNaN) {
+            throw new RangeError("NaN comparison not permitted");
         }
 
         if (!this.isFinite) {
@@ -1237,43 +1219,15 @@ export class Decimal128 {
         let rationalThis = this.rat;
         let rationalX = x.rat;
 
-        let ratCmp = rationalThis.cmp(rationalX);
-
-        if (ratCmp !== 0) {
-            return ratCmp;
-        }
-
-        if (!options.total) {
-            return 0;
-        }
-
-        if (this.isNegative && !x.isNegative) {
-            return -1;
-        }
-
-        if (!this.isNegative && x.isNegative) {
-            return 1;
-        }
-
-        let renderedThis = this.toString({
-            format: "decimal",
-            normalize: false,
-        });
-        let renderedX = x.toString({ format: "decimal", normalize: false });
-
-        if (renderedThis === renderedX) {
-            return 0;
-        }
-
-        return renderedThis > renderedX ? -1 : 1;
+        return rationalThis.cmp(rationalX);
     }
 
-    lessThan(x: Decimal128, opts?: CmpOptions): boolean {
-        return this.cmp(x, opts) === -1;
+    lessThan(x: Decimal128): boolean {
+        return this.cmp(x) === -1;
     }
 
-    equals(x: Decimal128, opts?: CmpOptions): boolean {
-        return this.cmp(x, opts) === 0;
+    equals(x: Decimal128): boolean {
+        return this.cmp(x) === 0;
     }
 
     abs(): Decimal128 {

--- a/tests/equals.test.js
+++ b/tests/equals.test.js
@@ -56,9 +56,6 @@ describe("equals", () => {
         test("use mathematical equality by default", () => {
             expect(a.equals(b)).toStrictEqual(true);
         });
-        test("take trailing zeroes into account", () => {
-            expect(a.equals(b, { normalize: true })).toStrictEqual(false);
-        });
         test("mathematically distinct", () => {
             expect(a.equals(c)).toStrictEqual(false);
         });
@@ -87,35 +84,14 @@ describe("many digits", () => {
         ).toStrictEqual(false);
     });
     describe("NaN", () => {
-        test("NaN equals NaN, even if total is false", () => {
-            expect(nan.equals(nan)).toStrictEqual(false);
+        test("NaN equals NaN throws", () => {
+            expect(() => nan.equals(nan)).toThrow(RangeError);
         });
-        test("NaN does equal NaN, with total comparison", () => {
-            expect(
-                nan.equals(nan, {
-                    normalize: true,
-                })
-            ).toStrictEqual(true);
+        test("number equals NaN throws", () => {
+            expect(() => one.equals(nan)).toThrow(RangeError);
         });
-        test("number equals NaN is false", () => {
-            expect(one.equals(nan)).toStrictEqual(false);
-        });
-        test("number equals NaN fails, with total comparison", () => {
-            expect(
-                one.equals(nan, {
-                    normalize: true,
-                })
-            ).toStrictEqual(false);
-        });
-        test("NaN equals number", () => {
-            expect(nan.equals(one)).toStrictEqual(false);
-        });
-        test("NaN equals number is false, with total comparison", () => {
-            expect(
-                nan.equals(one, {
-                    normalize: true,
-                })
-            ).toStrictEqual(false);
+        test("NaN equals number throws", () => {
+            expect(() => nan.equals(one)).toThrow(RangeError);
         });
     });
     describe("minus zero", () => {
@@ -169,12 +145,6 @@ describe("zero", () => {
     test("negative zero vs zero", () => {
         expect(negZero.equals(zero)).toStrictEqual(true);
     });
-    test("negative zero vs zero, normalization disabled", () => {
-        expect(negZero.equals(zero, { normalize: true })).toStrictEqual(false);
-    });
-    test("zero vs negative zero, normalization disabled", () => {
-        expect(zero.equals(negZero, { normalize: true })).toStrictEqual(false);
-    });
 });
 
 describe("normalization", () => {
@@ -189,18 +159,6 @@ describe("normalization", () => {
     });
     test("compare normalized to normalized", () => {
         expect(d1.equals(d3)).toStrictEqual(true);
-    });
-    test("compare non-normal (1)", () => {
-        expect(d1.equals(d2, { normalize: true })).toStrictEqual(false);
-    });
-    test("compare non-normal (2)", () => {
-        expect(d2.equals(d1, { normalize: true })).toStrictEqual(false);
-    });
-    test("compare two non-normal values", () => {
-        expect(d2.equals(d3, { normalize: true })).toStrictEqual(false);
-    });
-    test("compare two non-normal values", () => {
-        expect(d3.equals(d2, { normalize: true })).toStrictEqual(false);
     });
 });
 
@@ -247,104 +205,68 @@ describe("examples from the General Decimal Arithmetic specification", () => {
         });
         test("example two", () => {
             expect(
-                new Decimal128("-127").equals(new Decimal128("12"), {
-                    normalize: true,
-                })
+                new Decimal128("-127").equals(new Decimal128("12"))
             ).toStrictEqual(false);
         });
         test("example three", () => {
             expect(
-                new Decimal128("12.30").equals(new Decimal128("12.3"), {
-                    normalize: true,
-                })
-            ).toStrictEqual(false);
+                new Decimal128("12.30").equals(new Decimal128("12.3"))
+            ).toStrictEqual(true); // would be false if we didn't normalize
         });
         test("example four", () => {
             expect(
-                new Decimal128("12.30").equals(new Decimal128("12.30"), {
-                    normalize: true,
-                })
+                new Decimal128("12.30").equals(new Decimal128("12.30"))
             ).toStrictEqual(true);
         });
         test("example five", () => {
             expect(
-                new Decimal128("12.3").equals(new Decimal128("12.300"), {
-                    normalize: true,
-                })
-            ).toStrictEqual(false);
+                new Decimal128("12.3").equals(new Decimal128("12.300"))
+            ).toStrictEqual(true); // would be false if we didn't normalize
         });
         test("example six", () => {
-            expect(
-                new Decimal128("12.3").equals(new Decimal128("NaN"), {
-                    normalize: true,
-                })
-            ).toStrictEqual(false);
+            expect(() =>
+                new Decimal128("12.3").equals(new Decimal128("NaN"))
+            ).toThrow(RangeError); // wouldn't throw if we did a total comparison
         });
         describe("inline examples", () => {
             test("example one", () => {
                 expect(
-                    new Decimal128("-Infinity").equals(new Decimal128("-127"), {
-                        normalize: true,
-                    })
+                    new Decimal128("-Infinity").equals(new Decimal128("-127"))
                 ).toStrictEqual(false);
             });
             test("example two", () => {
                 expect(
-                    new Decimal128("-1.00").equals(new Decimal128("-1"), {
-                        normalize: true,
-                    })
-                ).toStrictEqual(false);
+                    new Decimal128("-1.00").equals(new Decimal128("-1"))
+                ).toStrictEqual(true); // would be false if we didn't normalize
             });
             test("example three", () => {
-                expect(
-                    new Decimal128("-0.000").equals(negZero, {
-                        normalize: true,
-                    })
-                ).toStrictEqual(false);
+                expect(new Decimal128("-0.000").equals(negZero)).toStrictEqual(
+                    true
+                ); // would be false if we didn't normalize
             });
             test("example four", () => {
-                expect(
-                    negZero.equals(zero, {
-                        normalize: true,
-                    })
-                ).toStrictEqual(false);
+                expect(negZero.equals(zero)).toStrictEqual(true); // would be false if we didn't normalize
             });
             test("example five", () => {
                 expect(
-                    new Decimal128("1.2300").equals(new Decimal128("1.23"), {
-                        normalize: true,
-                    })
-                ).toStrictEqual(false);
+                    new Decimal128("1.2300").equals(new Decimal128("1.23"))
+                ).toStrictEqual(true); // would be false if we didn't normalize
             });
             test("example six", () => {
                 expect(
-                    new Decimal128("1.23").equals(new Decimal128("1E+9"), {
-                        normalize: true,
-                    })
+                    new Decimal128("1.23").equals(new Decimal128("1E+9"))
                 ).toStrictEqual(false);
             });
             test("example seven", () => {
                 expect(
-                    new Decimal128("1E+9").equals(new Decimal128("Infinity"), {
-                        normalize: true,
-                    })
+                    new Decimal128("1E+9").equals(new Decimal128("Infinity"))
                 ).toStrictEqual(false);
             });
             test("example eight", () => {
-                expect(
-                    new Decimal128("Infinity").equals(new Decimal128("NaN"), {
-                        normalize: true,
-                    })
-                ).toStrictEqual(false);
+                expect(() =>
+                    new Decimal128("Infinity").equals(new Decimal128("NaN"))
+                ).toThrow(RangeError); // wouldn't throw if we did a total comparison
             });
         });
-    });
-});
-
-describe("examples from a presentation at TC39 plenary", () => {
-    test("NaN with a payload", () => {
-        expect(
-            new Decimal128("NaN").equals(new Decimal128("NaN123"))
-        ).toStrictEqual(false);
     });
 });

--- a/tests/lessthan.test.js
+++ b/tests/lessthan.test.js
@@ -61,9 +61,6 @@ describe("lessThan", () => {
         test("use mathematical equality by default", () => {
             expect(b.lessThan(a)).toStrictEqual(false);
         });
-        test("take trailing zeroes into account", () => {
-            expect(b.lessThan(a, { normalize: true })).toStrictEqual(true);
-        });
         test("mathematically distinct", () => {
             expect(a.lessThan(c)).toStrictEqual(true);
         });
@@ -85,33 +82,19 @@ describe("many digits", () => {
         ).toStrictEqual(true);
     });
     describe("NaN", () => {
-        test("NaN lessThan NaN is false", () => {
-            expect(nan.lessThan(nan)).toStrictEqual(false);
+        test("NaN lessThan NaN throws", () => {
+            expect(() => nan.lessThan(nan)).toThrow(RangeError);
         });
-        test("NaN lessThan NaN is not NaN, with total comparison", () => {
-            expect(nan.lessThan(nan, { normalize: true })).toStrictEqual(false);
+        test("number lessThan NaN throws", () => {
+            expect(() => one.lessThan(nan)).toThrow(RangeError);
         });
-        test("number lessThan NaN is true", () => {
-            expect(one.lessThan(nan)).toStrictEqual(false);
-        });
-        test("number lessThan NaN is not NaN, with total comparison", () => {
-            expect(one.lessThan(nan, { normalize: true })).toStrictEqual(true);
-        });
-        test("NaN lessThan number is false", () => {
-            expect(nan.lessThan(one)).toStrictEqual(false);
-        });
-        test("NaN lessThan number is false, with total comparison", () => {
-            expect(nan.lessThan(one, { normalize: true })).toStrictEqual(false);
+        test("NaN lessThan number throws ", () => {
+            expect(() => nan.lessThan(one)).toThrow(RangeError);
         });
     });
     describe("minus zero", () => {
         test("left hand", () => {
             expect(negZero.lessThan(zero)).toStrictEqual(false);
-        });
-        test("left hand, with total comparison", () => {
-            expect(negZero.lessThan(zero, { normalize: true })).toStrictEqual(
-                true
-            );
         });
         test("right hand", () => {
             expect(zero.lessThan(negZero)).toStrictEqual(false);
@@ -158,9 +141,6 @@ describe("zero", () => {
     test("negative zero vs zero", () => {
         expect(negZero.lessThan(zero)).toStrictEqual(false);
     });
-    test("negative zero vs zero, normalization disabled", () => {
-        expect(negZero.lessThan(zero, { normalize: true })).toStrictEqual(true);
-    });
     test("zero vs negative zero, normalization disabled", () => {
         expect(zero.lessThan(negZero, { normalize: true })).toStrictEqual(
             false
@@ -182,16 +162,13 @@ describe("normalization", () => {
         expect(d1.lessThan(d3)).toStrictEqual(false);
     });
     test("compare non-normal (1)", () => {
-        expect(d1.lessThan(d2, { normalize: true })).toStrictEqual(false);
-    });
-    test("compare non-normal (2)", () => {
-        expect(d2.lessThan(d1, { normalize: true })).toStrictEqual(true);
+        expect(d1.lessThan(d2)).toStrictEqual(false);
     });
     test("compare two non-normal values", () => {
-        expect(d2.lessThan(d3, { normalize: true })).toStrictEqual(false);
+        expect(d2.lessThan(d3)).toStrictEqual(false);
     });
     test("compare two non-normal values", () => {
-        expect(d3.lessThan(d2, { normalize: true })).toStrictEqual(true);
+        expect(d3.lessThan(d2)).toStrictEqual(false);
     });
 });
 
@@ -245,10 +222,8 @@ describe("examples from the General Decimal Arithmetic specification", () => {
         });
         test("example three", () => {
             expect(
-                new Decimal128("12.30").lessThan(new Decimal128("12.3"), {
-                    normalize: true,
-                })
-            ).toStrictEqual(true);
+                new Decimal128("12.30").lessThan(new Decimal128("12.3"))
+            ).toStrictEqual(false); // would be true if we were to respect trailing zeroes
         });
         test("example four", () => {
             expect(
@@ -265,75 +240,9 @@ describe("examples from the General Decimal Arithmetic specification", () => {
             ).toStrictEqual(false);
         });
         test("example six", () => {
-            expect(
-                new Decimal128("12.3").lessThan(new Decimal128("NaN"), {
-                    normalize: true,
-                })
-            ).toStrictEqual(true);
-        });
-        describe("inline examples", () => {
-            test("example one", () => {
-                expect(
-                    new Decimal128("-Infinity").lessThan(
-                        new Decimal128("-127"),
-                        {
-                            normalize: true,
-                        }
-                    )
-                ).toStrictEqual(true);
-            });
-            test("example two", () => {
-                expect(
-                    new Decimal128("-1.00").lessThan(new Decimal128("-1"), {
-                        normalize: true,
-                    })
-                ).toStrictEqual(true);
-            });
-            test("example three", () => {
-                expect(
-                    new Decimal128("-0.000").lessThan(new Decimal128("-0"), {
-                        normalize: true,
-                    })
-                ).toStrictEqual(true);
-            });
-            test("example four", () => {
-                expect(
-                    new Decimal128("-0").lessThan(new Decimal128("0"), {
-                        normalize: true,
-                    })
-                ).toStrictEqual(true);
-            });
-            test("example five", () => {
-                expect(
-                    new Decimal128("1.2300").lessThan(new Decimal128("1.23"), {
-                        normalize: true,
-                    })
-                ).toStrictEqual(true);
-            });
-            test("example six", () => {
-                expect(
-                    new Decimal128("1.23").lessThan(new Decimal128("1E+9"), {
-                        normalize: true,
-                    })
-                ).toStrictEqual(true);
-            });
-            test("example seven", () => {
-                expect(
-                    new Decimal128("1E+9").lessThan(
-                        new Decimal128("Infinity"),
-                        {
-                            normalize: true,
-                        }
-                    )
-                ).toStrictEqual(true);
-            });
-            test("example eight", () => {
-                expect(
-                    new Decimal128("Infinity").lessThan(new Decimal128("NaN"), {
-                        normalize: true,
-                    })
-                ).toStrictEqual(true);
-            });
+            expect(() =>
+                new Decimal128("12.3").lessThan(new Decimal128("NaN"))
+            ).toThrow(RangeError); // wouldn't throw if we were to use total ordering
         });
     });
 });


### PR DESCRIPTION
Make comparison by mathematical value the only way we do comparison. Comparison of digits strings, we e.g. 1.2 < 1.20, can be added later if needed.