### PR TITLE
A POC that replaces all BigInt to JSBI.BigInt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
             "name": "decimal128",
             "version": "20.1.0",
             "license": "ISC",
+            "dependencies": {
+                "jsbi": "^4.3.0"
+            },
             "devDependencies": {
                 "@rollup/plugin-typescript": "^12.1.1",
                 "@types/jest": "^29.5.1",
@@ -4959,6 +4962,11 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/jsbi": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+            "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
+        },
         "node_modules/jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -9797,6 +9805,11 @@
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
             }
+        },
+        "jsbi": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+            "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
         },
         "jsesc": {
             "version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     ],
     "author": "Jesse Alama <jesse@igalia.com>",
     "license": "ISC",
+    "dependencies": {
+        "jsbi": "^4.3.0"
+    },
     "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.1",
         "@types/jest": "^29.5.1",

--- a/src/Decimal.mts
+++ b/src/Decimal.mts
@@ -1,3 +1,4 @@
+import JSBI from "jsbi";
 import { Rational } from "./Rational.mjs";
 
 function _cohort(s: string): "0" | "-0" | Rational {
@@ -88,7 +89,7 @@ export class Decimal {
         });
     }
 
-    public coefficient(): bigint {
+    public coefficient(): JSBI {
         let v = this.cohort as Rational;
         let q = this.quantum;
         let c = v.scale10(0 - q);

--- a/tests/Decimal/constructor.test.js
+++ b/tests/Decimal/constructor.test.js
@@ -1,20 +1,21 @@
+import JSBI from "jsbi";
 import { Decimal } from "../../src/Decimal.mjs";
 import { Rational } from "../../src/Rational.mjs";
 
 describe("Decimal constructor", () => {
     test("fails if given zero", () => {
         expect(
-            () => new Decimal({ cohort: new Rational(0n, 1n), quantum: 0 })
+            () => new Decimal({ cohort: new Rational(JSBI.BigInt(0), JSBI.BigInt(1)), quantum: 0 })
         ).toThrow(RangeError);
     });
     test("fails if quantum is a non-integer", () => {
         expect(
-            () => new Decimal({ cohort: new Rational(1n, 1n), quantum: 1.5 })
+            () => new Decimal({ cohort: new Rational(JSBI.BigInt(1), JSBI.BigInt(1)), quantum: 1.5 })
         ).toThrow(RangeError);
     });
     test("fails if quantum is minus zero", () => {
         expect(
-            () => new Decimal({ cohort: new Rational(1n, 1n), quantum: -0 })
+            () => new Decimal({ cohort: new Rational(JSBI.BigInt(1), JSBI.BigInt(1)), quantum: -0 })
         ).toThrow(RangeError);
     });
 });

--- a/tests/Decimal128/constructor.test.js
+++ b/tests/Decimal128/constructor.test.js
@@ -1,3 +1,4 @@
+import JSBI from "jsbi";
 import { Decimal128 } from "../../src/Decimal128.mjs";
 
 const MAX_SIGNIFICANT_DIGITS = 34;
@@ -372,6 +373,17 @@ describe("bigint", () => {
     test("too big", () => {
         expect(
             new Decimal128(123456789012345678901234567890123456789n).toString()
+        ).toStrictEqual("Infinity");
+    });
+});
+
+describe("JSBI", () => {
+    test("simple", () => {
+        expect(new Decimal128(JSBI.BigInt(42)).toString()).toStrictEqual("42");
+    });
+    test("too big", () => {
+        expect(
+            new Decimal128(JSBI.BigInt("123456789012345678901234567890123456789")).toString()
         ).toStrictEqual("Infinity");
     });
 });

--- a/tests/Decimal128/scaledsignificand.test.js
+++ b/tests/Decimal128/scaledsignificand.test.js
@@ -1,3 +1,4 @@
+import JSBI from "jsbi";
 import { Decimal128 } from "../../src/Decimal128.mjs";
 
 describe("NaN", () => {
@@ -19,25 +20,25 @@ describe("infinities", () => {
 
 describe("finite values", () => {
     test("0", () => {
-        expect(new Decimal128("0").scaledSignificand()).toStrictEqual(0n);
+        expect(new Decimal128("0").scaledSignificand()).toStrictEqual(JSBI.BigInt(0));
     });
     test("-0", () => {
-        expect(new Decimal128("-0").scaledSignificand()).toStrictEqual(0n);
+        expect(new Decimal128("-0").scaledSignificand()).toStrictEqual(JSBI.BigInt(0));
     });
-    let solution = 420000000000000000000000000n;
+    let solution = JSBI.BigInt("420000000000000000000000000");
     test("simple number, greater than 10, with exponent apparently at limit", () => {
         expect(new Decimal128("42E-6143").scaledSignificand()).toStrictEqual(
-            42n * 10n ** 32n
+            JSBI.multiply(JSBI.BigInt(42), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(32)))
         );
     });
     test("simple number between 1 and 10 with exponent apparently at limit", () => {
         expect(new Decimal128("4.2E-6143").scaledSignificand()).toStrictEqual(
-            42n * 10n ** 32n
+            JSBI.multiply(JSBI.BigInt(42), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(32)))
         );
     });
     test("simple number with exponent beyond limit", () => {
         expect(new Decimal128("4.2E-6150").scaledSignificand()).toStrictEqual(
-            42n * 10n ** 25n
+            JSBI.multiply(JSBI.BigInt(42), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(25)))
         );
     });
 });

--- a/tests/Decimal128/tobigint.test.js
+++ b/tests/Decimal128/tobigint.test.js
@@ -1,3 +1,4 @@
+import JSBI from "jsbi";
 import { Decimal128 } from "../../src/Decimal128.mjs";
 
 describe("NaN", () => {
@@ -8,10 +9,10 @@ describe("NaN", () => {
 
 describe("zero", () => {
     test("positive zero", () => {
-        expect(new Decimal128("0").toBigInt()).toStrictEqual(0n);
+        expect(new Decimal128("0").toBigInt()).toStrictEqual(JSBI.BigInt(0));
     });
     test("negative zero", () => {
-        expect(new Decimal128("-0").toBigInt()).toStrictEqual(0n);
+        expect(new Decimal128("-0").toBigInt()).toStrictEqual(JSBI.BigInt(0));
     });
 });
 
@@ -31,15 +32,15 @@ describe("non-integer", () => {
         expect(() => new Decimal128("1.2").toBigInt()).toThrow(RangeError);
     });
     test("work with mathematical value (ignore trailing zeroes)", () => {
-        expect(new Decimal128("1.00").toBigInt()).toStrictEqual(1n);
+        expect(new Decimal128("1.00").toBigInt()).toStrictEqual(JSBI.BigInt(1));
     });
 });
 
 describe("simple examples", () => {
     test("42", () => {
-        expect(new Decimal128("42").toBigInt()).toStrictEqual(42n);
+        expect(new Decimal128("42").toBigInt()).toStrictEqual(JSBI.BigInt(42));
     });
     test("-123", () => {
-        expect(new Decimal128("-123").toBigInt()).toStrictEqual(-123n);
+        expect(new Decimal128("-123").toBigInt()).toStrictEqual(JSBI.BigInt(-123));
     });
 });

--- a/tests/Rational/rational.test.js
+++ b/tests/Rational/rational.test.js
@@ -1,64 +1,66 @@
+import JSBI from "jsbi";
 import { Rational } from "../../src/Rational.mjs";
+
 describe("constructor", () => {
     test("cannot divide by zero", () => {
-        expect(() => new Rational(1n, 0n)).toThrow(RangeError);
+        expect(() => new Rational(JSBI.BigInt(1), JSBI.BigInt(0))).toThrow(RangeError);
     });
     test("normalization happens at construction", () => {
-        let r = new Rational(2n, 4n);
-        expect(r.numerator).toStrictEqual(1n);
-        expect(r.denominator).toStrictEqual(2n);
+        let r = new Rational(JSBI.BigInt(2), JSBI.BigInt(4));
+        expect(r.numerator).toStrictEqual(JSBI.BigInt(1));
+        expect(r.denominator).toStrictEqual(JSBI.BigInt(2));
     });
     test("negative numerator", () => {
-        expect(new Rational(-1n, 2n).isNegative).toStrictEqual(true);
+        expect(new Rational(JSBI.BigInt(-1), JSBI.BigInt(2)).isNegative).toStrictEqual(true);
     });
     test("negative denominator", () => {
-        expect(new Rational(1n, -2n).isNegative).toStrictEqual(true);
+        expect(new Rational(JSBI.BigInt(1), JSBI.BigInt(-2)).isNegative).toStrictEqual(true);
     });
     test("negative numerator and denominator", () => {
-        expect(new Rational(-1n, -2n).isNegative).toStrictEqual(false);
+        expect(new Rational(JSBI.BigInt(-1), JSBI.BigInt(-2)).isNegative).toStrictEqual(false);
     });
 });
 
 describe("toString", () => {
     test("simple", () => {
-        expect(new Rational(1n, 2n).toString()).toStrictEqual("1/2");
+        expect(new Rational(JSBI.BigInt(1), JSBI.BigInt(2)).toString()).toStrictEqual("1/2");
     });
     test("negative", () => {
-        expect(new Rational(-3n, 7n).toString()).toStrictEqual("-3/7");
+        expect(new Rational(JSBI.BigInt(-3), JSBI.BigInt(7)).toString()).toStrictEqual("-3/7");
     });
 });
 
 describe("toFixed", () => {
     test("zero", () => {
-        let d = new Rational(0n, 1n);
+        let d = new Rational(JSBI.BigInt(0), JSBI.BigInt(1));
         expect(d.toFixed(1)).toStrictEqual("0.0");
         expect(d.toFixed(5)).toStrictEqual("0.00000");
     });
     test("exactly representable", () => {
-        expect(new Rational(3n, 2n).toFixed(1)).toStrictEqual("1.5");
-        expect(new Rational(1n, 2n).toFixed(1)).toStrictEqual("0.5");
-        expect(new Rational(1n, 5n).toFixed(1)).toStrictEqual("0.2");
-        expect(new Rational(367n, 1000n).toFixed(3)).toStrictEqual("0.367");
+        expect(new Rational(JSBI.BigInt(3), JSBI.BigInt(2)).toFixed(1)).toStrictEqual("1.5");
+        expect(new Rational(JSBI.BigInt(1), JSBI.BigInt(2)).toFixed(1)).toStrictEqual("0.5");
+        expect(new Rational(JSBI.BigInt(1), JSBI.BigInt(5)).toFixed(1)).toStrictEqual("0.2");
+        expect(new Rational(JSBI.BigInt(367), JSBI.BigInt(1000)).toFixed(3)).toStrictEqual("0.367");
     });
     test("more digits requested than necessary", () => {
-        expect(new Rational(3n, 2n).toFixed(3)).toStrictEqual("1.500");
+        expect(new Rational(JSBI.BigInt(3), JSBI.BigInt(2)).toFixed(3)).toStrictEqual("1.500");
     });
     test("not exactly representable", () => {
-        let third = new Rational(1n, 3n);
+        let third = new Rational(JSBI.BigInt(1), JSBI.BigInt(3));
         expect(third.toFixed(1)).toStrictEqual("0.3");
         expect(third.toFixed(2)).toStrictEqual("0.33");
         expect(third.toFixed(5)).toStrictEqual("0.33333");
     });
     test("representable, greater than one", () => {
-        expect(new Rational(5n, 2n).toFixed(2)).toStrictEqual("2.50");
+        expect(new Rational(JSBI.BigInt(5), JSBI.BigInt(2)).toFixed(2)).toStrictEqual("2.50");
     });
     test("not exactly representable, greater than one", () => {
-        expect(new Rational(5n, 3n).toFixed(2)).toStrictEqual("1.66");
+        expect(new Rational(JSBI.BigInt(5), JSBI.BigInt(3)).toFixed(2)).toStrictEqual("1.66");
     });
     test("non-integer value not OK", () => {
-        expect(() => new Rational(1n, 2n).toFixed(1.6)).toThrow(TypeError);
+        expect(() => new Rational(JSBI.BigInt(1), JSBI.BigInt(2)).toFixed(1.6)).toThrow(TypeError);
     });
     test("negative integer not OK", () => {
-        expect(() => new Rational(1n, 2n).toFixed(-1)).toThrow(RangeError);
+        expect(() => new Rational(JSBI.BigInt(1), JSBI.BigInt(2)).toFixed(-1)).toThrow(RangeError);
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,9 +27,9 @@
         // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
         /* Modules */
-        "module": "NodeNext" /* Specify what module code is generated. */,
+        "module": "ES2020"                                   /* Specify what module code is generated. */,
         // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-        "moduleResolution": "NodeNext" /* Specify how TypeScript looks up a file from a given module specifier. */,
+        "moduleResolution": "bundler"                        /* Specify how TypeScript looks up a file from a given module specifier. */,
         // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
         // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
         // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
## Summary

This is a proof of concept that replaces all reference of BigInt to JSBI

### ~~Technical note:~~
~~rollup config output interop is set to `default` to ensure compatibility between JSBI CJS default export and CJS environment~~ (doesn't seem necessary)

## Related

Related to #100

## How is this tested?

All existing tests pass @ d4789ffcbf546aff6eba6ff32187db52db3a5ef5
