### PR TITLE
fix: map exports to dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,15 @@
     "main": "dist/cjs/Decimal128.cjs",
     "module": "dist/esm/Decimal128.mjs",
     "typings": "dist/esm/Decimal128.d.ts",
+    "exports": {
+        "node": {
+            "module-sync": "./dist/esm/Decimal128.mjs",
+            "types": "./dist/esm/Decimal128.d.ts",
+            "default": "./dist/cjs/Decimal128.cjs"
+        },
+        "types": "./dist/esm/Decimal128.d.ts",
+        "default": "./dist/esm/Decimal128.mjs"
+    },
     "sideEffects": false,
     "scripts": {
         "build": "rollup -c",
@@ -53,8 +62,5 @@
             "type": "BSD-2-Clause",
             "url": "https://opensource.org/license/bsd-2-clause/"
         }
-    ],
-    "exports": {
-        ".": "./src/Decimal128.mjs"
-    }
+    ]
 }


### PR DESCRIPTION
## Summary

Update exports map to refer to files from `dist` folder

Reference taken for this exports map:
- https://github.com/nodejs/node/pull/54648 (first code snippet)

Related resources:
- https://github.com/jessealama/decimal128/pull/93#discussion_r1593960032 (thanks @ryzokuken to for pointing this out)
- https://github.com/nodejs/node/issues/52174#issuecomment-2323354310

## Related issue

Resolve #119 

Previously, `exports` reference to the non-transpiled typescript files in `src`.
This is generally undesirable as consumer may not be using Typescript.

In certain case (i.e. #119 in vite) it causes the bundler to transpile the code instead of using the already transpiled mjs, cjs files.

## How is this tested?

Attempted with the reproduce steps from #119.

Manually changing the export map in `./decimal128-tsc-issue/node_modules/decimal128/package.json` shows successful build.

![image](https://github.com/user-attachments/assets/ebcd01e3-7846-436a-92eb-badf954922c3)

(1)
```bash
npm create vite@latest decimal128-tsc-issue -- --template react-ts
cd decimal128-tsc-issue
npm install
npm install --save decimal128
echo "import { Decimal128 } from 'decimal128'" > .\src\App.tsx
echo "export default () => new Decimal128(123).toString()" >> .\src\App.tsx
```

(2)
Apply this change inside `./decimal128-tsc-issue/node_modules/decimal128/package.json`

(3)
```bash
npm run build
```